### PR TITLE
Filter Join Handling Improvements

### DIFF
--- a/src/main/java/com/hubspot/httpql/FieldFactory.java
+++ b/src/main/java/com/hubspot/httpql/FieldFactory.java
@@ -19,6 +19,8 @@ public interface FieldFactory {
 
   <T> Field<T> createField(String name, Class<T> fieldType, Table<?> table);
 
+  String getFieldName(String name, Table<?> table);
+
   Optional<String> tableAlias(String name);
 
 }

--- a/src/main/java/com/hubspot/httpql/impl/DefaultFieldFactory.java
+++ b/src/main/java/com/hubspot/httpql/impl/DefaultFieldFactory.java
@@ -21,6 +21,11 @@ public class DefaultFieldFactory implements FieldFactory {
   }
 
   @Override
+  public String getFieldName(String name, Table<?> table) {
+    return DSL.field(DSL.name(name)).toString();
+  }
+
+  @Override
   public Optional<String> tableAlias(String name) {
     return Optional.empty();
   }

--- a/src/main/java/com/hubspot/httpql/impl/PrefixingAliasFieldFactory.java
+++ b/src/main/java/com/hubspot/httpql/impl/PrefixingAliasFieldFactory.java
@@ -29,6 +29,11 @@ public class PrefixingAliasFieldFactory implements FieldFactory {
   }
 
   @Override
+  public String getFieldName(String name, Table<?> table) {
+    return DSL.field(name).toString();
+  }
+
+  @Override
   public Optional<String> tableAlias(String name) {
     return Optional.empty();
   }

--- a/src/main/java/com/hubspot/httpql/impl/TableQualifiedFieldFactory.java
+++ b/src/main/java/com/hubspot/httpql/impl/TableQualifiedFieldFactory.java
@@ -26,6 +26,11 @@ public class TableQualifiedFieldFactory implements FieldFactory {
   }
 
   @Override
+  public String getFieldName(String name, Table<?> table) {
+    return DSL.name(table.toString(), name).toString();
+  }
+
+  @Override
   public Optional<String> tableAlias(String name) {
     return Optional.empty();
   }


### PR DESCRIPTION
Updates to QueryParse and SelectBuilder to handle @FilterJoin annotation better. Joins are added to Select Builder at constructor now. Query parser handles FilterBy as field now. Exposing new methods on Select builder for Cog to use in getting raw SQL.
