### PR TITLE
HubSpot updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,3 +35,10 @@ Sound cool? `Get reading, then!`_
 .. _Rosetta: https://github.com/HubSpot/Rosetta
 .. _Jackson: http://wiki.fasterxml.com/JacksonHome
 .. _Get reading, then!: http://github.hubspot.com/httpQL/
+
+Class Loader StackOverflow Issue
+-------
+* Sometimes when including ``httpQL`` in your project you will run into intermittent issues where ``java.lang.ClassLoader.loadClass`` will throw a ``StackOverflow`` error. This is because your thread runs out of stack when trying to include all of the necessary classes. You can fix this by increasing your thread stack size with this deploy config option: ``JVM_STACK_SIZE: 384k``. It is only recommended to do this if you run into this issue.
+
+.. |BlazarShield| image:: https://private.hubapi.com/blazar/v2/branches/state/9954/shield
+.. _BlazarShield: https://private.hubteam.com/blazar/builds/branch/9954

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,11 @@
 
   <developers>
     <developer>
-      <id>jaredstehler</id>
       <name>Jared Stehler</name>
-      <email>jstehler@hubspot.com</email>
+    </developer>
+    <developer>
+      <name>Nate Belisle</name>
+      <email>nbelisle11@gmail.com</email>
     </developer>
   </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>12.5</version>
+    <version>15.11</version>
   </parent>
 
   <groupId>com.hubspot.httpql</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
 
   <developers>
     <developer>
+      <id>jaredstehler</id>
       <name>Jared Stehler</name>
     </developer>
     <developer>

--- a/src/main/java/com/hubspot/httpql/DefaultMetaUtils.java
+++ b/src/main/java/com/hubspot/httpql/DefaultMetaUtils.java
@@ -5,6 +5,7 @@ import java.lang.annotation.Annotation;
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Throwables;
@@ -13,6 +14,7 @@ import com.hubspot.httpql.ann.FilterJoin;
 import com.hubspot.httpql.ann.OrderBy;
 import com.hubspot.rosetta.annotations.RosettaNaming;
 
+@SuppressWarnings("deprecation")
 public class DefaultMetaUtils {
   @Nullable
   public static OrderBy findOrderBy(BeanPropertyDefinition prop) {
@@ -56,7 +58,10 @@ public class DefaultMetaUtils {
 
   public static String convertToSnakeCaseIfSupported(String name, Class<?> specType) {
     RosettaNaming rosettaNaming = getAnnotation(specType, RosettaNaming.class);
-    boolean snakeCasing = rosettaNaming != null && rosettaNaming.value().equals(LowerCaseWithUnderscoresStrategy.class);
+
+    boolean snakeCasing = rosettaNaming != null &&
+        (rosettaNaming.value().equals(LowerCaseWithUnderscoresStrategy.class) ||
+            rosettaNaming.value().equals(SnakeCaseStrategy.class));
 
     if (snakeCasing && !name.contains("_")) {
       return CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, name);

--- a/src/main/java/com/hubspot/httpql/FieldFactory.java
+++ b/src/main/java/com/hubspot/httpql/FieldFactory.java
@@ -19,6 +19,8 @@ public interface FieldFactory {
 
   <T> Field<T> createField(String name, Class<T> fieldType, Table<?> table);
 
+  String getFieldName(String name, Table<?> table);
+
   Optional<String> tableAlias(String name);
 
 }

--- a/src/main/java/com/hubspot/httpql/MetaQuerySpec.java
+++ b/src/main/java/com/hubspot/httpql/MetaQuerySpec.java
@@ -53,7 +53,7 @@ public interface MetaQuerySpec<T extends QuerySpec> {
    * This method should *not* perform validation on the entries in {@code filters} to, e.g., check for existence of the filter on the field.
    */
   Table<BoundFilterEntry<T>, String, BeanPropertyDefinition> tableFor(BeanPropertyDefinition field,
-                                                                      @SuppressWarnings("unchecked") Class<? extends Filter>... filters);
+      @SuppressWarnings("unchecked") Class<? extends Filter>... filters);
 
   Class<T> getQueryType();
 }

--- a/src/main/java/com/hubspot/httpql/MetaQuerySpec.java
+++ b/src/main/java/com/hubspot/httpql/MetaQuerySpec.java
@@ -53,7 +53,7 @@ public interface MetaQuerySpec<T extends QuerySpec> {
    * This method should *not* perform validation on the entries in {@code filters} to, e.g., check for existence of the filter on the field.
    */
   Table<BoundFilterEntry<T>, String, BeanPropertyDefinition> tableFor(BeanPropertyDefinition field,
-      @SuppressWarnings("unchecked") Class<? extends Filter>... filters);
+                                                                      @SuppressWarnings("unchecked") Class<? extends Filter>... filters);
 
   Class<T> getQueryType();
 }

--- a/src/main/java/com/hubspot/httpql/ParsedQuery.java
+++ b/src/main/java/com/hubspot/httpql/ParsedQuery.java
@@ -206,6 +206,7 @@ public class ParsedQuery<T extends QuerySpec> {
 
     cacheKeyParts.add(offset.orElse(0));
     cacheKeyParts.add(limit.orElse(0));
+    cacheKeyParts.add(includeDeleted);
 
     return StringUtils.join(cacheKeyParts, ":");
   }

--- a/src/main/java/com/hubspot/httpql/ann/OrderBy.java
+++ b/src/main/java/com/hubspot/httpql/ann/OrderBy.java
@@ -9,4 +9,24 @@ import java.lang.annotation.Target;
 @Target({
     ElementType.FIELD, ElementType.METHOD
 })
-public @interface OrderBy {};
+public @interface OrderBy {
+
+  /**
+   * Flag to indicate that we're sorting by a generated field (i.e. a non-db-column),
+   * so that we never try to qualify the field with the table name in the ORDER BY clause.
+   *
+   * i.e. isGenerated=true ensures we get:
+   *
+   *  SELECT LENGTH(name) as `name_length`
+   *    FROM `my_table`
+   *    ORDER BY `name_length`
+   *
+   * instead of:
+   *
+   *  SELECT LENGTH(name) as `name_length`
+   *    FROM `my_table`
+   *    ORDER BY `my_table`.`name_length`
+   *
+   * */
+  boolean isGenerated() default false;
+};

--- a/src/main/java/com/hubspot/httpql/doc/ApiDefinition.java
+++ b/src/main/java/com/hubspot/httpql/doc/ApiDefinition.java
@@ -42,7 +42,7 @@ public class ApiDefinition {
 
     private final SortedSet<String> filters;
 
-    FilterableField(String field, Class<?> fieldType, boolean sortable) {
+    public FilterableField(String field, Class<?> fieldType, boolean sortable) {
       this.field = field;
       this.fieldType = fieldType;
       this.sortable = sortable;

--- a/src/main/java/com/hubspot/httpql/doc/ApiDefinition.java
+++ b/src/main/java/com/hubspot/httpql/doc/ApiDefinition.java
@@ -42,7 +42,7 @@ public class ApiDefinition {
 
     private final SortedSet<String> filters;
 
-    public FilterableField(String field, Class<?> fieldType, boolean sortable) {
+    FilterableField(String field, Class<?> fieldType, boolean sortable) {
       this.field = field;
       this.fieldType = fieldType;
       this.sortable = sortable;

--- a/src/main/java/com/hubspot/httpql/filter/InsensitiveContains.java
+++ b/src/main/java/com/hubspot/httpql/filter/InsensitiveContains.java
@@ -10,7 +10,7 @@ import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.Filter;
 
 public class InsensitiveContains extends FilterBase implements Filter {
-  private static final Escaper escaper = Escapers.builder()
+  private static final Escaper ESCAPER = Escapers.builder()
       .addEscape('\\', "\\\\")
       .addEscape('%', "!%")
       .addEscape('_', "!_")
@@ -31,7 +31,7 @@ public class InsensitiveContains extends FilterBase implements Filter {
       @Override
       public Condition getCondition(Param<T> value) {
         String originalValue = (String) value.getValue();
-        String escapedValue = escaper.escape(originalValue);
+        String escapedValue = ESCAPER.escape(originalValue);
         return field.likeIgnoreCase('%' + escapedValue + '%', '!');
       }
 

--- a/src/main/java/com/hubspot/httpql/filter/NotLike.java
+++ b/src/main/java/com/hubspot/httpql/filter/NotLike.java
@@ -1,0 +1,39 @@
+package com.hubspot.httpql.filter;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+import org.jooq.Condition;
+import org.jooq.Field;
+
+import com.hubspot.httpql.ConditionProvider;
+import com.hubspot.httpql.Filter;
+import com.hubspot.httpql.MultiParamConditionProvider;
+
+public class NotLike extends FilterBase implements Filter {
+
+  @Override
+  public String[] names() {
+    return new String[] {
+        "nlike", "not_like"
+    };
+  }
+
+  @Override
+  public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
+    return new MultiParamConditionProvider<T>(field) {
+
+      @Override
+      public Condition getCondition(Collection<T> values) {
+        Iterator<T> iter = values.iterator();
+        Condition notLikeCondition = field.notLike((String) iter.next(), '!');
+        while (iter.hasNext()) {
+          notLikeCondition = notLikeCondition.and(field.notLike((String) iter.next(), '!'));
+        }
+        return notLikeCondition;
+      }
+
+    };
+  }
+
+}

--- a/src/main/java/com/hubspot/httpql/filter/Range.java
+++ b/src/main/java/com/hubspot/httpql/filter/Range.java
@@ -39,7 +39,7 @@ public class Range extends FilterBase implements Filter {
       @Override
       public Condition getCondition(Collection<T> values) {
         List<Number> valueList = new ArrayList<Number>((Collection<? extends Number>) values);
-        Preconditions.checkArgument(valueList.size() == 2);
+        Preconditions.checkArgument(valueList.size() == 2, "Range filters require exactly 2 parameters");
 
         Collections.sort(valueList, NUMBER_COMPARATOR);
         return field.between((T) valueList.get(0), (T) valueList.get(1));

--- a/src/main/java/com/hubspot/httpql/impl/DefaultFieldFactory.java
+++ b/src/main/java/com/hubspot/httpql/impl/DefaultFieldFactory.java
@@ -21,6 +21,11 @@ public class DefaultFieldFactory implements FieldFactory {
   }
 
   @Override
+  public String getFieldName(String name, Table<?> table) {
+    return DSL.field(DSL.name(name)).toString();
+  }
+
+  @Override
   public Optional<String> tableAlias(String name) {
     return Optional.empty();
   }

--- a/src/main/java/com/hubspot/httpql/impl/FieldFilter.java
+++ b/src/main/java/com/hubspot/httpql/impl/FieldFilter.java
@@ -1,0 +1,62 @@
+package com.hubspot.httpql.impl;
+
+import java.util.List;
+
+import com.google.common.collect.ImmutableList;
+import com.hubspot.httpql.Filter;
+
+public class FieldFilter {
+
+  private Filter filter;
+  private String field;
+  private List<String> values;
+  private String filterName;
+
+  public FieldFilter(Filter filter, String filterName, String field, List<String> values) {
+    this.filter = filter;
+    this.filterName = filterName;
+    this.field = field;
+    this.values = values;
+  }
+
+  public FieldFilter(Filter filter, String filterName, String field, String value) {
+    this.filter = filter;
+    this.filterName = filterName;
+    this.field = field;
+    this.values = ImmutableList.of(value);
+  }
+
+  public Filter getFilter() {
+    return filter;
+  }
+
+  public String getField() {
+    return field;
+  }
+
+  public List<String> getValues() {
+    return values;
+  }
+
+  public String getValue() {
+    if (values.isEmpty()) {
+      return null;
+    }
+    return values.get(0);
+  }
+
+  public String getFilterName() {
+    return filterName;
+  }
+
+  @Override
+  public String toString() {
+    return "FieldFilter{" +
+        "filter=" + filter +
+        ", field='" + field + '\'' +
+        ", values=" + values +
+        ", filterName='" + filterName + '\'' +
+        '}';
+  }
+}
+

--- a/src/main/java/com/hubspot/httpql/impl/ParsedUriParams.java
+++ b/src/main/java/com/hubspot/httpql/impl/ParsedUriParams.java
@@ -1,0 +1,74 @@
+package com.hubspot.httpql.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class ParsedUriParams {
+
+  private List<String> orderBys = new ArrayList<>();
+  private Optional<Integer> offset = Optional.empty();
+  private Optional<Integer> limit = Optional.empty();
+  private boolean includeDeleted;
+
+  private List<FieldFilter> fieldFilters = new ArrayList<>();
+
+  public List<String> getOrderBys() {
+    return orderBys;
+  }
+
+  public void setOrderBys(List<String> orderBys) {
+    this.orderBys = orderBys;
+  }
+
+  public Optional<Integer> getOffset() {
+    return offset;
+  }
+
+  public void setOffset(int offset) {
+    this.offset = Optional.of(offset);
+  }
+
+  public Optional<Integer> getLimit() {
+    return limit;
+  }
+
+  public void setLimit(int limit) {
+    this.limit = Optional.of(limit);
+  }
+
+  public boolean isIncludeDeleted() {
+    return includeDeleted;
+  }
+
+  public void setIncludeDeleted(boolean includeDeleted) {
+    this.includeDeleted = includeDeleted;
+  }
+
+  public List<FieldFilter> getFieldFilters() {
+    return fieldFilters;
+  }
+
+  public void addOrderBys(List<String> orders) {
+    if (orders == null) {
+      return;
+    }
+
+    orderBys.addAll(orders);
+  }
+
+  public void addFieldFilter(FieldFilter fieldFilter) {
+    fieldFilters.add(fieldFilter);
+  }
+
+  @Override
+  public String toString() {
+    return "ParsedUriParams{" +
+        "orderBys=" + orderBys +
+        ", offset=" + offset +
+        ", limit=" + limit +
+        ", includeDeleted=" + includeDeleted +
+        ", fieldFilters=" + fieldFilters +
+        '}';
+  }
+}

--- a/src/main/java/com/hubspot/httpql/impl/PrefixingAliasFieldFactory.java
+++ b/src/main/java/com/hubspot/httpql/impl/PrefixingAliasFieldFactory.java
@@ -29,6 +29,11 @@ public class PrefixingAliasFieldFactory implements FieldFactory {
   }
 
   @Override
+  public String getFieldName(String name, Table<?> table) {
+    return DSL.field(name).toString();
+  }
+
+  @Override
   public Optional<String> tableAlias(String name) {
     return Optional.empty();
   }

--- a/src/main/java/com/hubspot/httpql/impl/SelectBuilder.java
+++ b/src/main/java/com/hubspot/httpql/impl/SelectBuilder.java
@@ -338,11 +338,12 @@ public class SelectBuilder<T extends QuerySpec> {
     return sorts;
   }
 
-  private Field<?> getSortField(Ordering order) {
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  private Field getSortField(Ordering order) {
     Map<String, BeanPropertyDefinition> fieldMap = meta.getFieldMap();
     BeanPropertyDefinition bpd = fieldMap.get(order.getQueryName());
     String fieldName = order.getQueryName();
-    Class<?> fieldType = meta.getFieldType(order.getFieldName());
+    Class fieldType = meta.getFieldType(order.getFieldName());
     if (bpd.getField().getAnnotation(OrderBy.class).isGenerated()) {
       // it's possible to sort by generated fields
       // but we shouldn't qualify them with table name in the ORDER BY clause
@@ -397,7 +398,7 @@ class AdditionalCondition {
   public final Condition condition;
   public final boolean includeInCount;
 
-  AdditionalCondition(Condition condition, boolean includeInCount) {
+  public AdditionalCondition(Condition condition, boolean includeInCount) {
     this.condition = condition;
     this.includeInCount = includeInCount;
   }

--- a/src/main/java/com/hubspot/httpql/impl/SelectBuilder.java
+++ b/src/main/java/com/hubspot/httpql/impl/SelectBuilder.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.jooq.Condition;
 import org.jooq.DSLContext;
@@ -25,9 +26,12 @@ import org.jooq.conf.RenderNameStyle;
 import org.jooq.conf.Settings;
 import org.jooq.impl.DSL;
 
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
 import com.hubspot.httpql.FieldFactory;
+import com.hubspot.httpql.MetaQuerySpec;
 import com.hubspot.httpql.ParsedQuery;
 import com.hubspot.httpql.QuerySpec;
+import com.hubspot.httpql.ann.OrderBy;
 import com.hubspot.httpql.internal.BoundFilterEntry;
 import com.hubspot.httpql.internal.JoinFilter;
 
@@ -43,7 +47,7 @@ public class SelectBuilder<T extends QuerySpec> {
   private final List<AdditionalCondition> additionalConditions = new ArrayList<>();
   private final List<JoinCondition> joinConditions = new ArrayList<>();
   private final List<Field<?>> groupByFields = new ArrayList<>();
-  private final DefaultMetaQuerySpec<T> meta;
+  private final MetaQuerySpec<T> meta;
   private final ParsedQuery<T> sourceQuery;
 
   private FieldFactory factory = new DefaultFieldFactory();
@@ -54,9 +58,19 @@ public class SelectBuilder<T extends QuerySpec> {
   private boolean includeConstraints = true;
   private boolean asCount = false;
 
-  private SelectBuilder(ParsedQuery<T> parsed, DefaultMetaQuerySpec<T> context) {
+  private SelectBuilder(ParsedQuery<T> parsed, MetaQuerySpec<T> context) {
     this.sourceQuery = parsed;
     this.meta = context;
+
+    for (BoundFilterEntry<T> bfe : sourceQuery.getBoundFilterEntries()) {
+      if (bfe.getFilter() instanceof JoinFilter) {
+        JoinFilter joinFilter = (JoinFilter) bfe.getFilter();
+        joinConditions.add(joinFilter.getJoin());
+        if (factory instanceof DefaultFieldFactory) {
+          factory = new TableQualifiedFieldFactory();
+        }
+      }
+    }
   }
 
   /**
@@ -202,7 +216,7 @@ public class SelectBuilder<T extends QuerySpec> {
   }
 
   public BuiltSelect<T> build() {
-    return new BuiltSelect<T>(buildSelect(), paramType);
+    return new BuiltSelect<>(buildSelect(), paramType);
   }
 
   private Table<?> getTable() {
@@ -218,6 +232,14 @@ public class SelectBuilder<T extends QuerySpec> {
     return includedFields;
   }
 
+  public <F> Field<F> getFieldByName(String name, Class<F> type) {
+    return factory.createField(name, type, getTable());
+  }
+
+  public String getFieldName(String name) {
+    return factory.getFieldName(name, getTable());
+  }
+
   private SelectFinalStep<?> buildSelect() {
     Select<?> select;
     SelectFromStep<?> selectFrom;
@@ -225,8 +247,6 @@ public class SelectBuilder<T extends QuerySpec> {
     settings.setRenderNameStyle(renderNameStyle);
     DSLContext ctx = DSL.using(dialect, settings);
     Table<?> table = getTable();
-
-    Collection<JoinCondition> joins = getJoinConditions();
 
     if (asCount) {
       if (includedFieldNames.size() > 0) {
@@ -242,7 +262,7 @@ public class SelectBuilder<T extends QuerySpec> {
       } else {
         String tableName = sourceQuery.getBoundQuery().tableName();
 
-        if (joins.size() > 0) {
+        if (joinConditions.size() > 0) {
           selectStep = ctx.selectDistinct(DSL.field(tableName + ".*"));
         } else {
           selectStep = ctx.select(DSL.field("*"));
@@ -255,7 +275,7 @@ public class SelectBuilder<T extends QuerySpec> {
       }
     }
     select = selectFrom.from(table);
-    for (JoinCondition joinCondition : joins) {
+    for (JoinCondition joinCondition : joinConditions) {
       if (joinCondition.isLeftJoin()) {
         ((SelectJoinStep<?>) select).leftOuterJoin(joinCondition.getTable()).on(joinCondition.getCondition());
       } else {
@@ -298,39 +318,38 @@ public class SelectBuilder<T extends QuerySpec> {
     return conditions;
   }
 
-  public Collection<JoinCondition> getJoinConditions() {
-    Collection<JoinCondition> joins = new ArrayList<>();
-
-    for (BoundFilterEntry<T> bfe : sourceQuery.getBoundFilterEntries()) {
-      if (bfe.getFilter() instanceof JoinFilter) {
-        JoinFilter joinFilter = (JoinFilter) bfe.getFilter();
-        joins.add(joinFilter.getJoin());
-      }
-    }
-
-    joins.addAll(joinConditions);
-
-    return joins;
-  }
-
   public ParsedQuery<T> getSourceQuery() {
     return sourceQuery;
   }
 
-  public static <T extends QuerySpec> SelectBuilder<T> forParsedQuery(ParsedQuery<T> parsed, DefaultMetaQuerySpec<T> context) {
-    return new SelectBuilder<T>(parsed, context);
+  public static <T extends QuerySpec> SelectBuilder<T> forParsedQuery(ParsedQuery<T> parsed, MetaQuerySpec<T> context) {
+    return new SelectBuilder<>(parsed, context);
   }
 
   public static <T extends QuerySpec> SelectBuilder<T> forParsedQuery(ParsedQuery<T> parsed) {
-    return new SelectBuilder<T>(parsed, new DefaultMetaQuerySpec<T>(parsed.getQueryType()));
+    return new SelectBuilder<>(parsed, new DefaultMetaQuerySpec<>(parsed.getQueryType()));
   }
 
   public Collection<SortField<?>> orderingsToSortFields() {
     ArrayList<SortField<?>> sorts = new ArrayList<>(sourceQuery.getOrderings().size());
     for (Ordering order : sourceQuery.getOrderings()) {
-      sorts.add(factory.createField(order.getQueryName(), meta.getFieldType(order.getFieldName()), getTable()).sort(order.getOrder()));
+      sorts.add(getSortField(order).sort(order.getOrder()));
     }
     return sorts;
+  }
+
+  private Field<?> getSortField(Ordering order) {
+    Map<String, BeanPropertyDefinition> fieldMap = meta.getFieldMap();
+    BeanPropertyDefinition bpd = fieldMap.get(order.getQueryName());
+    String fieldName = order.getQueryName();
+    Class<?> fieldType = meta.getFieldType(order.getFieldName());
+    if (bpd.getField().getAnnotation(OrderBy.class).isGenerated()) {
+      // it's possible to sort by generated fields
+      // but we shouldn't qualify them with table name in the ORDER BY clause
+      return DSL.field(DSL.name(fieldName), fieldType);
+    } else {
+      return factory.createField(fieldName, fieldType, getTable());
+    }
   }
 
   public boolean containsSortField(String fieldName) {
@@ -378,7 +397,7 @@ class AdditionalCondition {
   public final Condition condition;
   public final boolean includeInCount;
 
-  public AdditionalCondition(Condition condition, boolean includeInCount) {
+  AdditionalCondition(Condition condition, boolean includeInCount) {
     this.condition = condition;
     this.includeInCount = includeInCount;
   }

--- a/src/main/java/com/hubspot/httpql/impl/TableQualifiedFieldFactory.java
+++ b/src/main/java/com/hubspot/httpql/impl/TableQualifiedFieldFactory.java
@@ -26,6 +26,11 @@ public class TableQualifiedFieldFactory implements FieldFactory {
   }
 
   @Override
+  public String getFieldName(String name, Table<?> table) {
+    return DSL.name(table.toString(), name).toString();
+  }
+
+  @Override
   public Optional<String> tableAlias(String name) {
     return Optional.empty();
   }

--- a/src/main/java/com/hubspot/httpql/impl/UriParamParser.java
+++ b/src/main/java/com/hubspot/httpql/impl/UriParamParser.java
@@ -1,0 +1,161 @@
+package com.hubspot.httpql.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+import java.util.Set;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.apache.commons.lang.BooleanUtils;
+import org.apache.commons.lang.math.NumberUtils;
+import org.jooq.impl.DSL;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimap;
+import com.hubspot.httpql.ConditionProvider;
+import com.hubspot.httpql.Filter;
+import com.hubspot.httpql.MultiParamConditionProvider;
+import com.hubspot.httpql.error.FilterViolation;
+import com.hubspot.httpql.filter.Equal;
+import com.sun.jersey.core.util.MultivaluedMapImpl;
+
+public class UriParamParser {
+
+  public static final Map<String, Filter> BY_NAME = new HashMap<>();
+  private static final ServiceLoader<Filter> LOADER = ServiceLoader.load(Filter.class);
+
+  private static final Splitter FILTER_PARAM_SPLITTER = Splitter.on("__").trimResults();
+  private static final Splitter MULTIVALUE_PARAM_SPLITTER = Splitter.on(",").omitEmptyStrings().trimResults();
+
+  static {
+    for (Filter filter : LOADER) {
+      for (String name : filter.names()) {
+        BY_NAME.put(name, filter);
+      }
+    }
+  }
+
+  private final Set<String> ignoredParams;
+
+  protected UriParamParser(Set<String> ignoredParams) {
+    this.ignoredParams = ignoredParams;
+  }
+
+  public Set<String> getIgnoredParams() {
+    return ignoredParams;
+  }
+
+  public MultivaluedMap<String, String> multimapToMultivaluedMap(Multimap<String, String> map) {
+
+    MultivaluedMap<String, String> result = new MultivaluedMapImpl();
+    for (Map.Entry<String, String> entry : map.entries()) {
+      result.add(entry.getKey(), entry.getValue());
+    }
+
+    return result;
+  }
+
+  public ParsedUriParams parseUriParams(Multimap<String, String> uriParams) {
+    return parseUriParams(multimapToMultivaluedMap(uriParams));
+  }
+
+  @SuppressWarnings("rawtypes")
+  public ParsedUriParams parseUriParams(MultivaluedMap<String, String> uriParams) {
+
+    final ParsedUriParams result = new ParsedUriParams();
+
+    // make a copy so we can modify it
+    MultivaluedMap<String, String> params = new MultivaluedMapImpl();
+    for (Map.Entry<String, List<String>> entry : uriParams.entrySet()) {
+      if (!ignoredParams.contains(entry.getKey().toLowerCase())) {
+        params.put(entry.getKey(), entry.getValue());
+      }
+    }
+
+    result.setIncludeDeleted(BooleanUtils.toBoolean(params.getFirst("includeDeleted")));
+    params.remove("includeDeleted");
+
+    final int limit = NumberUtils.toInt(params.getFirst("limit"), 0);
+    if (limit != 0) {
+      result.setLimit(limit);
+    }
+    params.remove("limit");
+
+    final int offset = NumberUtils.toInt(params.getFirst("offset"), 0);
+    if (offset != 0) {
+      result.setOffset(offset);
+    }
+    params.remove("offset");
+
+    result.addOrderBys(params.get("order"));
+    params.remove("order");
+    result.addOrderBys(params.get("orderBy"));
+    params.remove("orderBy");
+
+    for (Map.Entry<String, List<String>> entry : params.entrySet()) {
+      List<String> parts = FILTER_PARAM_SPLITTER.splitToList(entry.getKey().trim());
+      if (parts.size() > 2) {
+        continue;
+      }
+
+      final String fieldName = parts.get(0);
+      final String filterName = filterNameFromParts(parts);
+      final Filter filter = BY_NAME.get(filterName);
+
+      if (filter == null) {
+        throw new FilterViolation(String.format("Unknown filter type `%s`", filterName));
+      }
+
+      List<String> values = entry.getValue();
+      ConditionProvider conditionProvider = filter.getConditionProvider(DSL.field(fieldName));
+
+      if (conditionProvider instanceof MultiParamConditionProvider && values.size() == 1 && values.get(0).contains(",")) {
+        values = MULTIVALUE_PARAM_SPLITTER.splitToList(values.get(0));
+      }
+
+      result.addFieldFilter(new FieldFilter(filter, filterName, fieldName, values));
+    }
+
+    return result;
+  }
+
+  private static String filterNameFromParts(List<String> parts) {
+    if (parts.size() == 1) {
+      return (new Equal()).names()[0];
+    } else {
+      return parts.get(1);
+    }
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  public static class Builder {
+
+    protected Set<String> ignoredParams;
+
+    /**
+     * In Strict Mode, the parser will throw an Exception when an unknown query parameter is found, not only when a known field is not allowed to have the specified filter applied.
+     * <p>
+     * Defaults to OFF.
+     */
+    public Builder withIgnoredParams(Set<String> ignoredParams) {
+      this.ignoredParams = ignoredParams;
+      return this;
+    }
+
+    public UriParamParser build() {
+
+      if (ignoredParams == null) {
+        ignoredParams = ImmutableSet.of();
+      }
+
+      return new UriParamParser(ignoredParams);
+    }
+  }
+
+}

--- a/src/main/java/com/hubspot/httpql/internal/BoundFilterEntry.java
+++ b/src/main/java/com/hubspot/httpql/internal/BoundFilterEntry.java
@@ -45,7 +45,7 @@ public class BoundFilterEntry<T extends QuerySpec> extends FilterEntry {
 
   private static String getBestQueryName(BeanPropertyDefinition prop) {
     FilterBy ann = DefaultMetaUtils.findFilterBy(prop);
-    return Strings.emptyToNull(ann.as()) != null ? ann.as() : prop.getName();
+    return Strings.emptyToNull(ann == null ? "" : ann.as()) != null ? ann.as() : prop.getName();
   }
 
   public BeanPropertyDefinition getProperty() {

--- a/src/main/java/com/hubspot/httpql/jackson/BeanPropertyIntrospector.java
+++ b/src/main/java/com/hubspot/httpql/jackson/BeanPropertyIntrospector.java
@@ -1,7 +1,6 @@
 package com.hubspot.httpql.jackson;
 
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -67,20 +66,6 @@ public class BeanPropertyIntrospector {
     }
 
     return fieldType;
-  }
-
-  public static Type getGenericType(BeanPropertyDefinition definition) {
-    Type genericType = null;
-
-    if (definition.hasField()) {
-      genericType = definition.getField().getGenericType();
-    } else if (definition.hasGetter()) {
-      genericType = definition.getGetter().getGenericReturnType();
-    } else if (definition.hasSetter()) {
-      genericType = definition.getSetter().getGenericParameterType(0);
-    }
-
-    return genericType;
   }
 
   public static boolean hasAnnotation(BeanPropertyDefinition definition, Class<? extends Annotation> type) {

--- a/src/main/resources/META-INF/services/com.hubspot.httpql.Filter
+++ b/src/main/resources/META-INF/services/com.hubspot.httpql.Filter
@@ -12,3 +12,4 @@ com.hubspot.httpql.filter.Range
 com.hubspot.httpql.filter.StartsWith
 com.hubspot.httpql.filter.Null
 com.hubspot.httpql.filter.NotNull
+com.hubspot.httpql.filter.NotLike

--- a/src/test/java/com/hubspot/httpql/ParsedQueryTest.java
+++ b/src/test/java/com/hubspot/httpql/ParsedQueryTest.java
@@ -17,10 +17,12 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.hubspot.httpql.ann.FilterBy;
 import com.hubspot.httpql.ann.OrderBy;
+import com.hubspot.httpql.filter.Contains;
 import com.hubspot.httpql.filter.Equal;
 import com.hubspot.httpql.filter.GreaterThan;
 import com.hubspot.httpql.filter.In;
 import com.hubspot.httpql.filter.NotIn;
+import com.hubspot.httpql.filter.NotLike;
 import com.hubspot.httpql.impl.DefaultFieldFactory;
 import com.hubspot.httpql.impl.Ordering;
 import com.hubspot.httpql.impl.QueryParser;
@@ -142,6 +144,17 @@ public class ParsedQueryTest {
   }
 
   @Test
+  public void addNotLikeFilter() {
+    query.put("count__eq", "11");
+    ParsedQuery<Spec> parsed = parser.parse(query);
+
+    parsed.addFilter("comments", NotLike.class, Lists.newArrayList("%John%", "Jane%"));
+
+    assertThat(parsed.getBoundFilterEntries()).hasSize(2);
+    assertThat(parsed.hasFilter("comments"));
+  }
+
+  @Test
   public void itaddsOrderBy() {
     query.put("order", "-count");
     ParsedQuery<Spec> parsed = parser.parse(query);
@@ -195,7 +208,9 @@ public class ParsedQueryTest {
   }
 
   public enum SpecEnum {
-    TEST_ONE, TEST_TWO, TEST_THREE;
+    TEST_ONE,
+    TEST_TWO,
+    TEST_THREE;
 
     @Override
     public String toString() {
@@ -236,7 +251,7 @@ public class ParsedQueryTest {
     boolean secret;
 
     @FilterBy(value = {
-       In.class, NotIn.class
+        In.class, NotIn.class
     })
     private SpecEnum specEnum;
 
@@ -268,6 +283,11 @@ public class ParsedQueryTest {
       return secret;
     }
 
+    @FilterBy({
+        Contains.class, NotLike.class
+    })
+    String comments;
+
     /**
      * @param secret
      *          the secret to set
@@ -290,6 +310,14 @@ public class ParsedQueryTest {
 
     public void setSpecEnum(SpecEnum specEnum) {
       this.specEnum = specEnum;
+    }
+
+    public String getComments() {
+      return comments;
+    }
+
+    public void setComments(String comments) {
+      this.comments = comments;
     }
   }
 

--- a/src/test/java/com/hubspot/httpql/ParsedQueryTest.java
+++ b/src/test/java/com/hubspot/httpql/ParsedQueryTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.google.common.base.Enums;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
@@ -233,7 +233,7 @@ public class ParsedQueryTest {
   }
 
   @QueryConstraints(defaultLimit = 10, maxLimit = 100, maxOffset = 100)
-  @RosettaNaming(LowerCaseWithUnderscoresStrategy.class)
+  @RosettaNaming(SnakeCaseStrategy.class)
   public static class Spec extends SpecParent implements QuerySpec {
 
     @OrderBy

--- a/src/test/java/com/hubspot/httpql/SelectBuilderTest.java
+++ b/src/test/java/com/hubspot/httpql/SelectBuilderTest.java
@@ -13,9 +13,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
 import com.hubspot.httpql.ann.FilterBy;
 import com.hubspot.httpql.ann.OrderBy;
+import com.hubspot.httpql.filter.Contains;
 import com.hubspot.httpql.filter.Equal;
 import com.hubspot.httpql.filter.GreaterThan;
 import com.hubspot.httpql.filter.In;
+import com.hubspot.httpql.filter.NotLike;
 import com.hubspot.httpql.impl.PrefixingAliasFieldFactory;
 import com.hubspot.httpql.impl.QueryParser;
 import com.hubspot.httpql.impl.SelectBuilder;
@@ -39,10 +41,13 @@ public class SelectBuilderTest {
     query.put("count__gt", "100");
     query.put("full_name__eq", "example");
 
+    query.put("comments__nlike", "%John%");
+    query.put("comments__nlike", "Jane%");
+
     query.put("offset", "5");
 
     parsed = parser.parse(query);
-    queryFormat = "select * from example where (`id` in (%s, %s) and `count` > %s and `full_name` = %s) limit %s offset %s";
+    queryFormat = "select * from example where (`comments` not like %s escape '!' and `comments` not like %s escape '!' and `id` in (%s, %s) and `count` > %s and `full_name` = %s) limit %s offset %s";
   }
 
   @Test
@@ -51,7 +56,7 @@ public class SelectBuilderTest {
 
     String sql = selectBuilder.build().toString();
 
-    assertThat(sql).isEqualTo(String.format(queryFormat, "?", "?", "?", "?", "?", "?"));
+    assertThat(sql).isEqualTo(String.format(queryFormat, "?", "?", "?", "?", "?", "?", "?", "?"));
   }
 
   /**
@@ -64,7 +69,7 @@ public class SelectBuilderTest {
 
     String sql = selectBuilder.build().toString();
 
-    assertThat(sql).isEqualTo(String.format(queryFormat, ":1", ":2", ":count", ":full_name", ":5", ":6"));
+    assertThat(sql).isEqualTo(String.format(queryFormat, ":1", ":2", ":3", ":4", ":count", ":full_name", ":7", ":8"));
   }
 
   @Test
@@ -73,7 +78,7 @@ public class SelectBuilderTest {
 
     String sql = selectBuilder.build().toString();
 
-    assertThat(sql).isEqualTo(String.format(queryFormat, "1", "2", "100", "'example'", "10", "5"));
+    assertThat(sql).isEqualTo(String.format(queryFormat, "'%John%'", "'Jane%'", "1", "2", "100", "'example'", "10", "5"));
   }
 
   @Test
@@ -92,7 +97,7 @@ public class SelectBuilderTest {
 
     String sql = selectBuilder.build().toString();
 
-    assertThat(sql).startsWith("select id as `a.id`, full_name as `a.full_name` from example where (`a.id`");
+    assertThat(sql).startsWith("select id as `a.id`, full_name as `a.full_name` from example where (`a.comments` not like '%John%' escape '!' and `a.comments` not like 'Jane%' escape '!' and `a.id`");
   }
 
   @Test
@@ -102,7 +107,7 @@ public class SelectBuilderTest {
 
     String sql = selectBuilder.build().toString();
 
-    assertThat(sql).startsWith("select `example`.`id`, `example`.`full_name` from example where (`example`.`id`");
+    assertThat(sql).startsWith("select `example`.`id`, `example`.`full_name` from example where (`example`.`comments` not like '%John%' escape '!' and `example`.`comments` not like 'Jane%' escape '!' and `example`.`id`");
   }
 
   @Test
@@ -112,7 +117,7 @@ public class SelectBuilderTest {
 
     String sql = selectBuilder.build().toString();
 
-    assertThat(sql).isEqualTo("select count(*) from example where (`id` in (?, ?) and `count` > ? and `full_name` = ?)");
+    assertThat(sql).isEqualTo("select count(*) from example where (`comments` not like ? escape '!' and `comments` not like ? escape '!' and `id` in (?, ?) and `count` > ? and `full_name` = ?)");
   }
 
   @Test
@@ -204,6 +209,32 @@ public class SelectBuilderTest {
     assertThat(sql).contains("select `id`, `count`, IF(count > 0, 'true', 'false') as `is_positive` from example");
   }
 
+  @Test
+  public void withJoinAndOrderingByTableField() {
+    query.put("order", "fullName");
+    selectBuilder = parser.newSelectBuilder(query);
+
+    selectBuilder.withJoinCondition(DSL.table("other_table"),
+      DSL.field("example.full_name").eq(DSL.field("other_table.full_name")));
+
+    String sql = selectBuilder.build().toString();
+    assertThat(sql).contains("order by `example`.`full_name` asc");
+  }
+
+  @Test
+  public void withJoinAndOrderingByGeneratedField() {
+    query.put("order", "-name_length");
+    selectBuilder = parser.newSelectBuilder(query);
+
+    selectBuilder.withAdditionalFields(DSL.field("LENGTH(name)").as("name_length"));
+    selectBuilder.withJoinCondition(DSL.table("other_table"),
+      DSL.field("example.full_name").eq(DSL.field("other_table.full_name")));
+
+    String sql = selectBuilder.build().toString();
+    assertThat(sql).contains("order by `name_length` desc");
+
+  }
+
   @QueryConstraints(defaultLimit = 10, maxLimit = 100, maxOffset = 100)
   @RosettaNaming(LowerCaseWithUnderscoresStrategy.class)
   public static class Spec implements QuerySpec {
@@ -217,11 +248,19 @@ public class SelectBuilderTest {
     @OrderBy
     Long count;
 
+    @OrderBy(isGenerated = true)
+    Integer nameLength;
+
     @FilterBy(Equal.class)
     @OrderBy
     String fullName;
 
     boolean secret;
+
+    @FilterBy({
+        Contains.class, NotLike.class
+    })
+    String comments;
 
     @Override
     public String tableName() {
@@ -260,6 +299,21 @@ public class SelectBuilderTest {
       this.secret = secret;
     }
 
+    public Integer getNameLength() {
+      return nameLength;
+    }
+
+    public void setNameLength(Integer nameLength) {
+      this.nameLength = nameLength;
+    }
+
+    public String getComments() {
+      return comments;
+    }
+
+    public void setComments(String comments) {
+      this.comments = comments;
+    }
   }
 
 }

--- a/src/test/java/com/hubspot/httpql/SelectBuilderTest.java
+++ b/src/test/java/com/hubspot/httpql/SelectBuilderTest.java
@@ -7,7 +7,7 @@ import org.jooq.impl.DSL;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
@@ -215,7 +215,7 @@ public class SelectBuilderTest {
     selectBuilder = parser.newSelectBuilder(query);
 
     selectBuilder.withJoinCondition(DSL.table("other_table"),
-      DSL.field("example.full_name").eq(DSL.field("other_table.full_name")));
+        DSL.field("example.full_name").eq(DSL.field("other_table.full_name")));
 
     String sql = selectBuilder.build().toString();
     assertThat(sql).contains("order by `example`.`full_name` asc");
@@ -228,7 +228,7 @@ public class SelectBuilderTest {
 
     selectBuilder.withAdditionalFields(DSL.field("LENGTH(name)").as("name_length"));
     selectBuilder.withJoinCondition(DSL.table("other_table"),
-      DSL.field("example.full_name").eq(DSL.field("other_table.full_name")));
+        DSL.field("example.full_name").eq(DSL.field("other_table.full_name")));
 
     String sql = selectBuilder.build().toString();
     assertThat(sql).contains("order by `name_length` desc");
@@ -236,7 +236,7 @@ public class SelectBuilderTest {
   }
 
   @QueryConstraints(defaultLimit = 10, maxLimit = 100, maxOffset = 100)
-  @RosettaNaming(LowerCaseWithUnderscoresStrategy.class)
+  @RosettaNaming(SnakeCaseStrategy.class)
   public static class Spec implements QuerySpec {
 
     @FilterBy({

--- a/src/test/java/com/hubspot/httpql/impl/QueryParserTest.java
+++ b/src/test/java/com/hubspot/httpql/impl/QueryParserTest.java
@@ -4,13 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Optional;
 
-import javax.ws.rs.core.MultivaluedMap;
-
 import org.apache.commons.lang.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Multimap;
@@ -24,7 +22,6 @@ import com.hubspot.httpql.filter.Equal;
 import com.hubspot.httpql.filter.GreaterThan;
 import com.hubspot.httpql.filter.In;
 import com.hubspot.rosetta.annotations.RosettaNaming;
-import com.sun.jersey.core.util.MultivaluedMapImpl;
 
 public class QueryParserTest {
 
@@ -66,16 +63,6 @@ public class QueryParserTest {
 
     assertThat(StringUtils.normalizeSpace(SelectBuilder.forParsedQuery(parsedQuery).build().getRawSelect().toString()))
         .isEqualTo("select * from where `id` in ( 1, 2, 3 ) limit 10");
-  }
-
-
-  @Test
-  public void itPreservesCommasInEqValues() {
-    MultivaluedMap<String, String> query = new MultivaluedMapImpl();
-    query.add("name", "1,2,3");
-
-    final ParsedUriParams parsedUriParams = QueryParser.parseUriParams(query);
-    assertThat(parsedUriParams.getFieldFilters().get(0).getValue()).isEqualTo("1,2,3");
   }
 
   @Test
@@ -137,24 +124,6 @@ public class QueryParserTest {
   }
 
   @Test
-  public void itRemovesReservedParams() {
-
-    MultivaluedMap<String, String> query = new MultivaluedMapImpl();
-    query.add("offset", "1");
-    query.add("limit", "1");
-    query.add("includeDeleted", "1");
-    query.add("order", "1");
-    query.add("orderBy", "1");
-    query.add("orderBy", "2");
-    query.add("access_TOKEN", "2");
-    query.add("hapiKEY", "2");
-
-    final ParsedUriParams parsedUriParams = QueryParser.parseUriParams(query);
-    assertThat(parsedUriParams.getOrderBys()).hasSize(3);
-    assertThat(parsedUriParams.getFieldFilters()).isEmpty();
-  }
-
-  @Test
   public void itGetsLimitAndOffset() {
     Optional<Integer> limit = parser.getLimit(Optional.of(20));
     assertThat(limit.get()).isEqualTo(20);
@@ -171,7 +140,7 @@ public class QueryParserTest {
   }
 
   @QueryConstraints(defaultLimit = 10, maxLimit = 100, maxOffset = 100)
-  @RosettaNaming(LowerCaseWithUnderscoresStrategy.class)
+  @RosettaNaming(SnakeCaseStrategy.class)
   public static class Spec implements QuerySpec {
 
     @FilterBy({

--- a/src/test/java/com/hubspot/httpql/impl/UriParamParserTest.java
+++ b/src/test/java/com/hubspot/httpql/impl/UriParamParserTest.java
@@ -1,0 +1,45 @@
+package com.hubspot.httpql.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.ws.rs.core.MultivaluedMap;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sun.jersey.core.util.MultivaluedMapImpl;
+
+public class UriParamParserTest {
+  UriParamParser uriParamParser;
+
+  @Before
+  public void setup() {
+    uriParamParser = UriParamParser.newBuilder().build();
+  }
+
+  @Test
+  public void itRemovesReservedParams() {
+
+    MultivaluedMap<String, String> query = new MultivaluedMapImpl();
+    query.add("offset", "1");
+    query.add("limit", "1");
+    query.add("includeDeleted", "1");
+    query.add("order", "1");
+    query.add("orderBy", "1");
+    query.add("orderBy", "2");
+
+    final ParsedUriParams parsedUriParams = uriParamParser.parseUriParams(query);
+    assertThat(parsedUriParams.getOrderBys()).hasSize(3);
+    assertThat(parsedUriParams.getFieldFilters()).isEmpty();
+  }
+
+  @Test
+  public void itPreservesCommasInEqValues() {
+    MultivaluedMap<String, String> query = new MultivaluedMapImpl();
+    query.add("name", "1,2,3");
+
+    final ParsedUriParams parsedUriParams = uriParamParser.parseUriParams(query);
+    assertThat(parsedUriParams.getFieldFilters().get(0).getValue()).isEqualTo("1,2,3");
+  }
+
+}

--- a/src/test/java/com/hubspot/httpql/model/EntityWithJoin.java
+++ b/src/test/java/com/hubspot/httpql/model/EntityWithJoin.java
@@ -1,6 +1,6 @@
 package com.hubspot.httpql.model;
 
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.hubspot.httpql.QueryConstraints;
 import com.hubspot.httpql.QuerySpec;
 import com.hubspot.httpql.ann.FilterBy;
@@ -9,7 +9,7 @@ import com.hubspot.httpql.filter.Equal;
 import com.hubspot.httpql.filter.In;
 import com.hubspot.rosetta.annotations.RosettaNaming;
 
-@RosettaNaming(LowerCaseWithUnderscoresStrategy.class)
+@RosettaNaming(SnakeCaseStrategy.class)
 @QueryConstraints(defaultLimit = 10, maxLimit = 100, maxOffset = 1000)
 public class EntityWithJoin implements QuerySpec {
 


### PR DESCRIPTION
Updates 
- Updates to `QueryParse` and `SelectBuilder` to handle `@FilterJoin` annotation better
- Remove deprecated `getGenericType` usage in BeanPropertyIntrospector
- Added `NotLike` filter
- Add `isGenerated` flag to `@OrderBy` annotation
- Allow use of custom `QueryParser` and `MetaQuerySpec` implementations
- Add `FieldFilter` and `ParsedUriParams` for higher-level query abstraction without field mapping
- Prevent comma lists on single-value filters
- Add `UriParamParser` for non `QuerySpec` parsing 
- Support `ignoredParams` in `UriParamParser`
- Updates for Jackson changes