### PR TITLE
Remove uses of MultivaluedMap

### DIFF
--- a/docs/javadoc/com/hubspot/httpql/impl/QueryParser-Builder.rst
+++ b/docs/javadoc/com/hubspot/httpql/impl/QueryParser-Builder.rst
@@ -12,8 +12,6 @@
 
 .. java:import:: java.util Set
 
-.. java:import:: javax.ws.rs.core MultivaluedMap
-
 .. java:import:: javax.ws.rs.core UriInfo
 
 .. java:import:: com.fasterxml.jackson.databind.introspect BeanPropertyDefinition
@@ -67,8 +65,6 @@
 .. java:import:: com.hubspot.rosetta RosettaMapperFactory
 
 .. java:import:: com.hubspot.rosetta Tablet
-
-.. java:import:: com.sun.jersey.core.util MultivaluedMapImpl
 
 QueryParser.Builder
 ===================

--- a/docs/javadoc/com/hubspot/httpql/impl/QueryParser.rst
+++ b/docs/javadoc/com/hubspot/httpql/impl/QueryParser.rst
@@ -12,8 +12,6 @@
 
 .. java:import:: java.util Set
 
-.. java:import:: javax.ws.rs.core MultivaluedMap
-
 .. java:import:: javax.ws.rs.core UriInfo
 
 .. java:import:: com.fasterxml.jackson.databind.introspect BeanPropertyDefinition
@@ -67,8 +65,6 @@
 .. java:import:: com.hubspot.rosetta RosettaMapperFactory
 
 .. java:import:: com.hubspot.rosetta Tablet
-
-.. java:import:: com.sun.jersey.core.util MultivaluedMapImpl
 
 QueryParser
 ===========
@@ -139,7 +135,7 @@ newSelectBuilder
 newSelectBuilder
 ^^^^^^^^^^^^^^^^
 
-.. java:method:: public SelectBuilder<T> newSelectBuilder(MultivaluedMap<String, String> query)
+.. java:method:: public SelectBuilder<T> newSelectBuilder(Map<String, List<String>> query)
    :outertype: QueryParser
 
 parse
@@ -157,7 +153,7 @@ parse
 parse
 ^^^^^
 
-.. java:method:: public ParsedQuery<T> parse(MultivaluedMap<String, String> uriParams)
+.. java:method:: public ParsedQuery<T> parse(Map<String, List<String>> uriParams)
    :outertype: QueryParser
 
 setConstraints

--- a/src/main/java/com/hubspot/httpql/impl/QueryParser.java
+++ b/src/main/java/com/hubspot/httpql/impl/QueryParser.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.UriInfo;
 
 import org.slf4j.Logger;
@@ -43,7 +42,6 @@ import com.hubspot.httpql.internal.FilterEntry;
 import com.hubspot.httpql.internal.MultiValuedBoundFilterEntry;
 import com.hubspot.httpql.jackson.BeanPropertyIntrospector;
 import com.hubspot.rosetta.Rosetta;
-import com.sun.jersey.core.util.MultivaluedMapImpl;
 
 /**
  * Primary entry point into httpQL.
@@ -103,6 +101,10 @@ public class QueryParser<T extends QuerySpec> {
     return new Builder<>(spec);
   }
 
+  /**
+   * @deprecated Call {@code parse(uriInfo.getQueryParameters())} instead.
+   */
+  @Deprecated
   public ParsedQuery<T> parse(UriInfo uriInfo) {
     return parse(uriInfo.getQueryParameters());
   }
@@ -112,10 +114,10 @@ public class QueryParser<T extends QuerySpec> {
   }
 
   public ParsedQuery<T> createEmptyQuery() {
-    return parse(new MultivaluedMapImpl());
+    return parse(new HashMap<>());
   }
 
-  public ParsedQuery<T> parse(MultivaluedMap<String, String> uriParams) {
+  public ParsedQuery<T> parse(Map<String, List<String>> uriParams) {
     final Map<String, Object> fieldValues = new HashMap<>();
     final List<BoundFilterEntry<T>> boundFilterEntries = new ArrayList<>();
 
@@ -206,15 +208,19 @@ public class QueryParser<T extends QuerySpec> {
     }
   }
 
-  public SelectBuilder<T> newSelectBuilder(UriInfo query) {
-    return SelectBuilder.forParsedQuery(parse(query), meta);
+  /**
+   * @deprecated Call {@code newSelectBuilder(uriInfo.getQueryParameters())} instead.
+   */
+  @Deprecated
+  public SelectBuilder<T> newSelectBuilder(UriInfo uriInfo) {
+    return SelectBuilder.forParsedQuery(parse(uriInfo), meta);
   }
 
   public SelectBuilder<T> newSelectBuilder(Multimap<String, String> query) {
     return SelectBuilder.forParsedQuery(parse(query), meta);
   }
 
-  public SelectBuilder<T> newSelectBuilder(MultivaluedMap<String, String> query) {
+  public SelectBuilder<T> newSelectBuilder(Map<String, List<String>> query) {
     return SelectBuilder.forParsedQuery(parse(query), meta);
   }
 

--- a/src/main/java/com/hubspot/httpql/impl/UriParamParser.java
+++ b/src/main/java/com/hubspot/httpql/impl/UriParamParser.java
@@ -1,12 +1,12 @@
 package com.hubspot.httpql.impl;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
-
-import javax.ws.rs.core.MultivaluedMap;
 
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.math.NumberUtils;
@@ -20,7 +20,6 @@ import com.hubspot.httpql.Filter;
 import com.hubspot.httpql.MultiParamConditionProvider;
 import com.hubspot.httpql.error.FilterViolation;
 import com.hubspot.httpql.filter.Equal;
-import com.sun.jersey.core.util.MultivaluedMapImpl;
 
 public class UriParamParser {
 
@@ -48,13 +47,9 @@ public class UriParamParser {
     return ignoredParams;
   }
 
-  public MultivaluedMap<String, String> multimapToMultivaluedMap(Multimap<String, String> map) {
-
-    MultivaluedMap<String, String> result = new MultivaluedMapImpl();
-    for (Map.Entry<String, String> entry : map.entries()) {
-      result.add(entry.getKey(), entry.getValue());
-    }
-
+  public Map<String, List<String>> multimapToMultivaluedMap(Multimap<String, String> map) {
+    Map<String, List<String>> result = new HashMap<>();
+    map.asMap().forEach((key, value) -> result.put(key, new ArrayList<>(value)));
     return result;
   }
 
@@ -63,28 +58,24 @@ public class UriParamParser {
   }
 
   @SuppressWarnings("rawtypes")
-  public ParsedUriParams parseUriParams(MultivaluedMap<String, String> uriParams) {
+  public ParsedUriParams parseUriParams(Map<String, List<String>> uriParams) {
 
     final ParsedUriParams result = new ParsedUriParams();
 
     // make a copy so we can modify it
-    MultivaluedMap<String, String> params = new MultivaluedMapImpl();
-    for (Map.Entry<String, List<String>> entry : uriParams.entrySet()) {
-      if (!ignoredParams.contains(entry.getKey().toLowerCase())) {
-        params.put(entry.getKey(), entry.getValue());
-      }
-    }
+    Map<String, List<String>> params = new HashMap<>();
+    uriParams.forEach((key, value) -> params.put(key, new ArrayList<>(value)));
 
-    result.setIncludeDeleted(BooleanUtils.toBoolean(params.getFirst("includeDeleted")));
+    result.setIncludeDeleted(BooleanUtils.toBoolean(getFirst(params, "includeDeleted").orElse(null)));
     params.remove("includeDeleted");
 
-    final int limit = NumberUtils.toInt(params.getFirst("limit"), 0);
+    final int limit = NumberUtils.toInt(getFirst(params, "limit").orElse(null), 0);
     if (limit != 0) {
       result.setLimit(limit);
     }
     params.remove("limit");
 
-    final int offset = NumberUtils.toInt(params.getFirst("offset"), 0);
+    final int offset = NumberUtils.toInt(getFirst(params, "offset").orElse(null), 0);
     if (offset != 0) {
       result.setOffset(offset);
     }
@@ -158,4 +149,9 @@ public class UriParamParser {
     }
   }
 
+  private static Optional<String> getFirst(Map<String, List<String>> map, String key) {
+    return Optional.ofNullable(map.get(key))
+        .filter(list -> !list.isEmpty())
+        .map(list -> list.get(0));
+  }
 }

--- a/src/main/java/com/hubspot/httpql/impl/UriParamParser.java
+++ b/src/main/java/com/hubspot/httpql/impl/UriParamParser.java
@@ -8,6 +8,8 @@ import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.math.NumberUtils;
 import org.jooq.impl.DSL;
@@ -70,16 +72,16 @@ public class UriParamParser {
       }
     }
 
-    result.setIncludeDeleted(BooleanUtils.toBoolean(getFirst(params, "includeDeleted").orElse(null)));
+    result.setIncludeDeleted(BooleanUtils.toBoolean(getFirst(params, "includeDeleted")));
     params.remove("includeDeleted");
 
-    final int limit = NumberUtils.toInt(getFirst(params, "limit").orElse(null), 0);
+    final int limit = NumberUtils.toInt(getFirst(params, "limit"), 0);
     if (limit != 0) {
       result.setLimit(limit);
     }
     params.remove("limit");
 
-    final int offset = NumberUtils.toInt(getFirst(params, "offset").orElse(null), 0);
+    final int offset = NumberUtils.toInt(getFirst(params, "offset"), 0);
     if (offset != 0) {
       result.setOffset(offset);
     }
@@ -153,9 +155,11 @@ public class UriParamParser {
     }
   }
 
-  private static Optional<String> getFirst(Map<String, List<String>> map, String key) {
+  @Nullable
+  private static String getFirst(Map<String, List<String>> map, String key) {
     return Optional.ofNullable(map.get(key))
         .filter(list -> !list.isEmpty())
-        .map(list -> list.get(0));
+        .map(list -> list.get(0))
+        .orElse(null);
   }
 }

--- a/src/main/java/com/hubspot/httpql/impl/UriParamParser.java
+++ b/src/main/java/com/hubspot/httpql/impl/UriParamParser.java
@@ -64,7 +64,11 @@ public class UriParamParser {
 
     // make a copy so we can modify it
     Map<String, List<String>> params = new HashMap<>();
-    uriParams.forEach((key, value) -> params.put(key, new ArrayList<>(value)));
+    for (Map.Entry<String, List<String>> entry : uriParams.entrySet()) {
+      if (!ignoredParams.contains(entry.getKey().toLowerCase())) {
+        params.put(entry.getKey(), entry.getValue());
+      }
+    }
 
     result.setIncludeDeleted(BooleanUtils.toBoolean(getFirst(params, "includeDeleted").orElse(null)));
     params.remove("includeDeleted");

--- a/src/test/java/com/hubspot/httpql/impl/UriParamParserTest.java
+++ b/src/test/java/com/hubspot/httpql/impl/UriParamParserTest.java
@@ -2,12 +2,14 @@ package com.hubspot.httpql.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.ws.rs.core.MultivaluedMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import org.assertj.core.util.Lists;
 import org.junit.Before;
 import org.junit.Test;
-
-import com.sun.jersey.core.util.MultivaluedMapImpl;
 
 public class UriParamParserTest {
   UriParamParser uriParamParser;
@@ -20,13 +22,12 @@ public class UriParamParserTest {
   @Test
   public void itRemovesReservedParams() {
 
-    MultivaluedMap<String, String> query = new MultivaluedMapImpl();
-    query.add("offset", "1");
-    query.add("limit", "1");
-    query.add("includeDeleted", "1");
-    query.add("order", "1");
-    query.add("orderBy", "1");
-    query.add("orderBy", "2");
+    Map<String, List<String>> query = new HashMap<>();
+    query.put("offset", Lists.newArrayList("1"));
+    query.put("limit", Lists.newArrayList("1"));
+    query.put("includeDeleted", Lists.newArrayList("1"));
+    query.put("order", Lists.newArrayList("1"));
+    query.put("orderBy", Lists.newArrayList("1", "2"));
 
     final ParsedUriParams parsedUriParams = uriParamParser.parseUriParams(query);
     assertThat(parsedUriParams.getOrderBys()).hasSize(3);
@@ -35,8 +36,7 @@ public class UriParamParserTest {
 
   @Test
   public void itPreservesCommasInEqValues() {
-    MultivaluedMap<String, String> query = new MultivaluedMapImpl();
-    query.add("name", "1,2,3");
+    Map<String, List<String>> query = Collections.singletonMap("name", Collections.singletonList("1,2,3"));
 
     final ParsedUriParams parsedUriParams = uriParamParser.parseUriParams(query);
     assertThat(parsedUriParams.getFieldFilters().get(0).getValue()).isEqualTo("1,2,3");


### PR DESCRIPTION
As discussed on an internal issue, this is part of removing JAX/ Jersey dependencies from `httpQL`.

This PR will be followed by a rebuild of dependent projects (to avoid binary runtime failures) as well as eventual removal of the deprecated methods.

@nbelisle11 @jhaber 