### PR TITLE
Remove deprecated methods that operate on UriInfo

### DIFF
--- a/docs/javadoc/com/hubspot/httpql/impl/QueryParser-Builder.rst
+++ b/docs/javadoc/com/hubspot/httpql/impl/QueryParser-Builder.rst
@@ -12,8 +12,6 @@
 
 .. java:import:: java.util Set
 
-.. java:import:: javax.ws.rs.core UriInfo
-
 .. java:import:: com.fasterxml.jackson.databind.introspect BeanPropertyDefinition
 
 .. java:import:: com.google.common.base Optional

--- a/docs/javadoc/com/hubspot/httpql/impl/QueryParser.rst
+++ b/docs/javadoc/com/hubspot/httpql/impl/QueryParser.rst
@@ -12,8 +12,6 @@
 
 .. java:import:: java.util Set
 
-.. java:import:: javax.ws.rs.core UriInfo
-
 .. java:import:: com.fasterxml.jackson.databind.introspect BeanPropertyDefinition
 
 .. java:import:: com.google.common.base Optional
@@ -123,12 +121,6 @@ newBuilder
 newSelectBuilder
 ^^^^^^^^^^^^^^^^
 
-.. java:method:: public SelectBuilder<T> newSelectBuilder(UriInfo query)
-   :outertype: QueryParser
-
-newSelectBuilder
-^^^^^^^^^^^^^^^^
-
 .. java:method:: public SelectBuilder<T> newSelectBuilder(Multimap<String, String> query)
    :outertype: QueryParser
 
@@ -136,12 +128,6 @@ newSelectBuilder
 ^^^^^^^^^^^^^^^^
 
 .. java:method:: public SelectBuilder<T> newSelectBuilder(Map<String, List<String>> query)
-   :outertype: QueryParser
-
-parse
-^^^^^
-
-.. java:method:: public ParsedQuery<T> parse(UriInfo uriInfo)
    :outertype: QueryParser
 
 parse

--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,6 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>jsr311-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.sun.jersey</groupId>
       <artifactId>jersey-core</artifactId>
     </dependency>

--- a/src/main/java/com/hubspot/httpql/impl/QueryParser.java
+++ b/src/main/java/com/hubspot/httpql/impl/QueryParser.java
@@ -11,8 +11,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import javax.ws.rs.core.UriInfo;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,14 +97,6 @@ public class QueryParser<T extends QuerySpec> {
 
   public static <T extends QuerySpec> Builder<T> newBuilder(Class<T> spec) {
     return new Builder<>(spec);
-  }
-
-  /**
-   * @deprecated Call {@code parse(uriInfo.getQueryParameters())} instead.
-   */
-  @Deprecated
-  public ParsedQuery<T> parse(UriInfo uriInfo) {
-    return parse(uriInfo.getQueryParameters());
   }
 
   public ParsedQuery<T> parse(Multimap<String, String> uriParams) {
@@ -206,14 +196,6 @@ public class QueryParser<T extends QuerySpec> {
       }
       throw e;
     }
-  }
-
-  /**
-   * @deprecated Call {@code newSelectBuilder(uriInfo.getQueryParameters())} instead.
-   */
-  @Deprecated
-  public SelectBuilder<T> newSelectBuilder(UriInfo uriInfo) {
-    return SelectBuilder.forParsedQuery(parse(uriInfo), meta);
   }
 
   public SelectBuilder<T> newSelectBuilder(Multimap<String, String> query) {

--- a/src/main/java/com/hubspot/httpql/jersey/BindQueryInjectableProvider.java
+++ b/src/main/java/com/hubspot/httpql/jersey/BindQueryInjectableProvider.java
@@ -23,7 +23,7 @@ public class BindQueryInjectableProvider implements InjectableProvider<BindQuery
     return new AbstractHttpContextInjectable<ParsedQuery<? extends QuerySpec>>() {
       @Override
       public ParsedQuery<? extends QuerySpec> getValue(HttpContext context) {
-        return QueryParser.newBuilder(a.value()).build().parse(context.getUriInfo());
+        return QueryParser.newBuilder(a.value()).build().parse(context.getUriInfo().getQueryParameters());
       }
     };
   }


### PR DESCRIPTION
This is a follow-up to https://github.com/HubSpot/httpQL/pull/5. See the internal issue for searches that show these are unused.

@nbelisle @boulter 
/cc @jhaber 