### PR TITLE
New functionality to support more complex filter joins

### DIFF
--- a/src/main/java/com/hubspot/httpql/DefaultMetaUtils.java
+++ b/src/main/java/com/hubspot/httpql/DefaultMetaUtils.java
@@ -10,7 +10,9 @@ import com.google.common.base.CaseFormat;
 import com.google.common.base.Throwables;
 import com.hubspot.httpql.ann.FilterBy;
 import com.hubspot.httpql.ann.FilterJoin;
+import com.hubspot.httpql.ann.FilterJoinByDescriptor;
 import com.hubspot.httpql.ann.OrderBy;
+import com.hubspot.httpql.ann.desc.JoinDescriptor;
 import com.hubspot.rosetta.annotations.RosettaNaming;
 
 public class DefaultMetaUtils {
@@ -27,6 +29,24 @@ public class DefaultMetaUtils {
   @Nullable
   public static FilterJoin findFilterJoin(BeanPropertyDefinition prop) {
     return findAnnotation(prop, FilterJoin.class);
+  }
+
+  @Nullable
+  public static FilterJoinByDescriptor findFilterJoinByDescriptor(BeanPropertyDefinition prop) {
+    return findAnnotation(prop, FilterJoinByDescriptor.class);
+  }
+
+  @Nullable
+  public static JoinDescriptor findJoinDescriptor(BeanPropertyDefinition prop) {
+    try {
+      FilterJoinByDescriptor filterJoinByDescriptor = findFilterJoinByDescriptor(prop);
+      if (filterJoinByDescriptor == null) {
+        return null;
+      }
+      return findFilterJoinByDescriptor(prop).value().newInstance();
+    } catch (InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public static <T extends Annotation> T findAnnotation(BeanPropertyDefinition prop, Class<T> type) {

--- a/src/main/java/com/hubspot/httpql/ann/FilterJoinByDescriptor.java
+++ b/src/main/java/com/hubspot/httpql/ann/FilterJoinByDescriptor.java
@@ -1,0 +1,16 @@
+package com.hubspot.httpql.ann;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import com.hubspot.httpql.ann.desc.JoinDescriptor;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({
+    ElementType.FIELD, ElementType.METHOD
+})
+public @interface FilterJoinByDescriptor {
+  Class<? extends JoinDescriptor> value();
+}

--- a/src/main/java/com/hubspot/httpql/ann/desc/JoinDescriptor.java
+++ b/src/main/java/com/hubspot/httpql/ann/desc/JoinDescriptor.java
@@ -1,0 +1,14 @@
+package com.hubspot.httpql.ann.desc;
+
+import org.jooq.Field;
+
+import com.hubspot.httpql.QuerySpec;
+import com.hubspot.httpql.impl.JoinCondition;
+import com.hubspot.httpql.internal.FilterEntry;
+
+public interface JoinDescriptor {
+
+  Field<?> getField(FilterEntry filterEntry);
+
+  JoinCondition getJoinCondition(QuerySpec querySpec);
+}

--- a/src/main/java/com/hubspot/httpql/internal/BoundFilterEntry.java
+++ b/src/main/java/com/hubspot/httpql/internal/BoundFilterEntry.java
@@ -15,9 +15,10 @@ import com.hubspot.httpql.MultiParamConditionProvider;
 import com.hubspot.httpql.QuerySpec;
 import com.hubspot.httpql.ann.FilterBy;
 import com.hubspot.httpql.ann.FilterJoin;
+import com.hubspot.httpql.ann.desc.JoinDescriptor;
 import com.hubspot.httpql.impl.DefaultFieldFactory;
 
-public class BoundFilterEntry<T extends QuerySpec> extends FilterEntry {
+public class BoundFilterEntry<T extends QuerySpec>extends FilterEntry {
 
   private final BeanPropertyDefinition prop;
   private final MetaQuerySpec<T> meta;
@@ -64,8 +65,11 @@ public class BoundFilterEntry<T extends QuerySpec> extends FilterEntry {
     Field<?> field;
 
     FilterJoin join = DefaultMetaUtils.findFilterJoin(prop);
+    JoinDescriptor joinDescriptor = DefaultMetaUtils.findJoinDescriptor(prop);
     if (join != null) {
       field = DSL.field(DSL.name(join.table(), getQueryName()));
+    } else if (joinDescriptor != null) {
+      field = joinDescriptor.getField(this);
     } else {
       field = meta.createField(getQueryName(), fieldFactory);
     }

--- a/src/test/java/com/hubspot/httpql/impl/QueryParserComplexJoinDescriptorTest.java
+++ b/src/test/java/com/hubspot/httpql/impl/QueryParserComplexJoinDescriptorTest.java
@@ -1,0 +1,68 @@
+package com.hubspot.httpql.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.commons.lang.StringUtils;
+import org.jooq.SelectFinalStep;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.hubspot.httpql.ParsedQuery;
+import com.hubspot.httpql.model.EntityWithComplexJoinDescriptor;
+
+public class QueryParserComplexJoinDescriptorTest {
+
+  private Multimap<String, String> query;
+  private QueryParser<EntityWithComplexJoinDescriptor> parser;
+
+  @Before
+  public void setup() {
+    query = ArrayListMultimap.create();
+    parser = QueryParser.newBuilder(EntityWithComplexJoinDescriptor.class).build();
+  }
+
+  @Test
+  public void joinWithSingleBoundValue() {
+    query.put("topicId__eq", "123");
+
+    ParsedQuery<EntityWithComplexJoinDescriptor> parsedQuery = parser.parse(query);
+    assertThat(parsedQuery.getBoundQuery().getTopicId()).isEqualTo(123L);
+
+    SelectBuilder<EntityWithComplexJoinDescriptor> selectBuilder = SelectBuilder.forParsedQuery(parsedQuery);
+
+    SelectFinalStep<?> sql = selectBuilder.build().getRawSelect();
+
+    assertThat(StringUtils.normalizeSpace(sql.toString()))
+        .isEqualTo("select distinct entity_table.* from entity_table "
+            + "left outer join `join_tbl` on ( "
+            + "`entity_table`.`group_id` = `join_tbl`.`id` "
+            + "and `entity_table`.`tag` = `join_tbl`.`id` "
+            + "and `join_tbl`.`meta_type` = 'joinObjects' ) "
+            + "where ifnull(`join_tbl`.`topic_id`, 0) = '123' "
+            + "limit 10");
+  }
+
+  @Test
+  public void joinWithMultipleBoundValues() {
+    query.put("topicId__in", "123");
+    query.put("topicId__in", "456");
+
+    ParsedQuery<EntityWithComplexJoinDescriptor> parsedQuery = parser.parse(query);
+
+    SelectBuilder<EntityWithComplexJoinDescriptor> selectBuilder = SelectBuilder.forParsedQuery(parsedQuery);
+
+    SelectFinalStep<?> sql = selectBuilder.build().getRawSelect();
+
+    assertThat(StringUtils.normalizeSpace(sql.toString()))
+        .isEqualTo("select distinct entity_table.* from entity_table "
+            + "left outer join `join_tbl` on ( "
+            + "`entity_table`.`group_id` = `join_tbl`.`id` "
+            + "and `entity_table`.`tag` = `join_tbl`.`id` "
+            + "and `join_tbl`.`meta_type` = 'joinObjects' ) "
+            + "where ifnull(`join_tbl`.`topic_id`, 0) in ( 123, 456 ) "
+            + "limit 10");
+  }
+
+}

--- a/src/test/java/com/hubspot/httpql/impl/QueryParserSimpleJoinDescriptorTest.java
+++ b/src/test/java/com/hubspot/httpql/impl/QueryParserSimpleJoinDescriptorTest.java
@@ -10,27 +10,27 @@ import org.junit.Test;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.hubspot.httpql.ParsedQuery;
-import com.hubspot.httpql.model.EntitySimpleWithJoin;
+import com.hubspot.httpql.model.EntityWithSimpleJoinDescriptor;
 
-public class QueryParserJoinTest {
+public class QueryParserSimpleJoinDescriptorTest {
 
   private Multimap<String, String> query;
-  private QueryParser<EntitySimpleWithJoin> parser;
+  private QueryParser<EntityWithSimpleJoinDescriptor> parser;
 
   @Before
   public void setup() {
     query = ArrayListMultimap.create();
-    parser = QueryParser.newBuilder(EntitySimpleWithJoin.class).build();
+    parser = QueryParser.newBuilder(EntityWithSimpleJoinDescriptor.class).build();
   }
 
   @Test
   public void joinWithSingleBoundValue() {
     query.put("topicId__eq", "123");
 
-    ParsedQuery<EntitySimpleWithJoin> parsedQuery = parser.parse(query);
+    ParsedQuery<EntityWithSimpleJoinDescriptor> parsedQuery = parser.parse(query);
     assertThat(parsedQuery.getBoundQuery().getTopicId()).isEqualTo(123L);
 
-    SelectBuilder<EntitySimpleWithJoin> selectBuilder = SelectBuilder.forParsedQuery(parsedQuery);
+    SelectBuilder<EntityWithSimpleJoinDescriptor> selectBuilder = SelectBuilder.forParsedQuery(parsedQuery);
 
     SelectFinalStep<?> sql = selectBuilder.build().getRawSelect();
 
@@ -45,9 +45,9 @@ public class QueryParserJoinTest {
     query.put("topicId__in", "123");
     query.put("topicId__in", "456");
 
-    ParsedQuery<EntitySimpleWithJoin> parsedQuery = parser.parse(query);
+    ParsedQuery<EntityWithSimpleJoinDescriptor> parsedQuery = parser.parse(query);
 
-    SelectBuilder<EntitySimpleWithJoin> selectBuilder = SelectBuilder.forParsedQuery(parsedQuery);
+    SelectBuilder<EntityWithSimpleJoinDescriptor> selectBuilder = SelectBuilder.forParsedQuery(parsedQuery);
 
     SelectFinalStep<?> sql = selectBuilder.build().getRawSelect();
 

--- a/src/test/java/com/hubspot/httpql/model/EntityComplexJoinDescriptor.java
+++ b/src/test/java/com/hubspot/httpql/model/EntityComplexJoinDescriptor.java
@@ -1,0 +1,30 @@
+package com.hubspot.httpql.model;
+
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+
+import com.hubspot.httpql.QuerySpec;
+import com.hubspot.httpql.ann.desc.JoinDescriptor;
+import com.hubspot.httpql.impl.JoinCondition;
+import com.hubspot.httpql.internal.FilterEntry;
+
+public class EntityComplexJoinDescriptor implements JoinDescriptor {
+  private static final String JOIN_TABLE_NAME = "join_tbl";
+
+  @Override
+  public Field<?> getField(FilterEntry filterEntry) {
+    return DSL.nvl(DSL.field(DSL.name(JOIN_TABLE_NAME, filterEntry.getQueryName())), 0);
+  }
+
+  @Override
+  public JoinCondition getJoinCondition(QuerySpec querySpec) {
+    return new JoinCondition(DSL.table(DSL.name(JOIN_TABLE_NAME)),
+        DSL.field(DSL.name(querySpec.tableName(), "group_id"))
+            .eq(DSL.field(DSL.name(JOIN_TABLE_NAME, "id")))
+            .and(DSL.field(DSL.name(querySpec.tableName(), "tag"))
+                .eq(DSL.field(DSL.name(JOIN_TABLE_NAME, "id"))))
+            .and(DSL.field(DSL.name(JOIN_TABLE_NAME, "meta_type"))
+                .eq("joinObjects")),
+        true);
+  }
+}

--- a/src/test/java/com/hubspot/httpql/model/EntitySimpleJoinDescriptor.java
+++ b/src/test/java/com/hubspot/httpql/model/EntitySimpleJoinDescriptor.java
@@ -1,0 +1,25 @@
+package com.hubspot.httpql.model;
+
+import org.jooq.Field;
+import org.jooq.impl.DSL;
+
+import com.hubspot.httpql.QuerySpec;
+import com.hubspot.httpql.ann.desc.JoinDescriptor;
+import com.hubspot.httpql.impl.JoinCondition;
+import com.hubspot.httpql.internal.FilterEntry;
+
+public class EntitySimpleJoinDescriptor implements JoinDescriptor {
+  private static final String JOIN_TABLE_NAME = "join_tbl";
+
+  @Override
+  public Field<?> getField(FilterEntry filterEntry) {
+    return DSL.field(DSL.name(JOIN_TABLE_NAME, filterEntry.getQueryName()));
+  }
+
+  @Override
+  public JoinCondition getJoinCondition(QuerySpec querySpec) {
+    return new JoinCondition(DSL.table(DSL.name(JOIN_TABLE_NAME)),
+        DSL.field(DSL.name(querySpec.tableName(), "id"))
+            .eq(DSL.field(DSL.name(JOIN_TABLE_NAME, "entity_id"))));
+  }
+}

--- a/src/test/java/com/hubspot/httpql/model/EntitySimpleWithJoin.java
+++ b/src/test/java/com/hubspot/httpql/model/EntitySimpleWithJoin.java
@@ -11,7 +11,7 @@ import com.hubspot.rosetta.annotations.RosettaNaming;
 
 @RosettaNaming(LowerCaseWithUnderscoresStrategy.class)
 @QueryConstraints(defaultLimit = 10, maxLimit = 100, maxOffset = 1000)
-public class EntityWithJoin implements QuerySpec {
+public class EntitySimpleWithJoin implements QuerySpec {
 
   @FilterBy(Equal.class)
   private Long id;

--- a/src/test/java/com/hubspot/httpql/model/EntityWithComplexJoinDescriptor.java
+++ b/src/test/java/com/hubspot/httpql/model/EntityWithComplexJoinDescriptor.java
@@ -1,0 +1,44 @@
+package com.hubspot.httpql.model;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.hubspot.httpql.QueryConstraints;
+import com.hubspot.httpql.QuerySpec;
+import com.hubspot.httpql.ann.FilterBy;
+import com.hubspot.httpql.ann.FilterJoinByDescriptor;
+import com.hubspot.httpql.filter.Equal;
+import com.hubspot.httpql.filter.In;
+import com.hubspot.rosetta.annotations.RosettaNaming;
+
+@RosettaNaming(SnakeCaseStrategy.class)
+@QueryConstraints(defaultLimit = 10, maxLimit = 100, maxOffset = 1000)
+public class EntityWithComplexJoinDescriptor implements QuerySpec {
+
+  @FilterBy(Equal.class)
+  private Long id;
+
+  @FilterBy(value = {In.class, Equal.class})
+  @FilterJoinByDescriptor(EntityComplexJoinDescriptor.class)
+  private Long topicId;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public Long getTopicId() {
+    return topicId;
+  }
+
+  public void setTopicId(Long topicId) {
+    this.topicId = topicId;
+  }
+
+  @Override
+  public String tableName() {
+    return "entity_table";
+  }
+
+}

--- a/src/test/java/com/hubspot/httpql/model/EntityWithSimpleJoinDescriptor.java
+++ b/src/test/java/com/hubspot/httpql/model/EntityWithSimpleJoinDescriptor.java
@@ -1,0 +1,44 @@
+package com.hubspot.httpql.model;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
+import com.hubspot.httpql.QueryConstraints;
+import com.hubspot.httpql.QuerySpec;
+import com.hubspot.httpql.ann.FilterBy;
+import com.hubspot.httpql.ann.FilterJoinByDescriptor;
+import com.hubspot.httpql.filter.Equal;
+import com.hubspot.httpql.filter.In;
+import com.hubspot.rosetta.annotations.RosettaNaming;
+
+@RosettaNaming(SnakeCaseStrategy.class)
+@QueryConstraints(defaultLimit = 10, maxLimit = 100, maxOffset = 1000)
+public class EntityWithSimpleJoinDescriptor implements QuerySpec {
+
+  @FilterBy(Equal.class)
+  private Long id;
+
+  @FilterBy(value = {In.class, Equal.class})
+  @FilterJoinByDescriptor(EntitySimpleJoinDescriptor.class)
+  private Long topicId;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
+  }
+
+  public Long getTopicId() {
+    return topicId;
+  }
+
+  public void setTopicId(Long topicId) {
+    this.topicId = topicId;
+  }
+
+  @Override
+  public String tableName() {
+    return "entity_table";
+  }
+
+}


### PR DESCRIPTION
Expands on the existing (but simple) FilterJoin to create a new annotation which accepts a `JoinDescriptor` implementation which can specify much more complicated join and select logic.