### PR TITLE
Added toQueryParam method to FieldFilter

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/impl/FieldFilter.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/FieldFilter.java
@@ -1,6 +1,7 @@
 package com.hubspot.httpql.impl;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.google.common.collect.ImmutableList;
 import com.hubspot.httpql.Filter;
@@ -57,6 +58,10 @@ public class FieldFilter {
         ", values=" + values +
         ", filterName='" + filterName + '\'' +
         '}';
+  }
+  
+  public String toQueryParam() {
+    return this.field + "__" + filterName + "=" + values.stream().collect(Collectors.joining(","));
   }
 }
 


### PR DESCRIPTION
Added toQueryParam method to FieldFilter. I want to use this as a cache key and I could not use toString() method because of the way its formatted.