### PR TITLE
Add isDistinctFrom

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/filter/IsDistinctFrom.java
+++ b/httpql/src/main/java/com/hubspot/httpql/filter/IsDistinctFrom.java
@@ -1,9 +1,11 @@
 package com.hubspot.httpql.filter;
 
 import java.util.Collection;
+import java.util.stream.Collectors;
 
 import org.jooq.Condition;
 import org.jooq.Field;
+import org.jooq.impl.DSL;
 
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.Filter;
@@ -24,10 +26,9 @@ public class IsDistinctFrom extends FilterBase implements Filter {
 
       @Override
       public Condition getCondition(Collection<T> values) {
-        return values.stream()
+        return DSL.and(values.stream()
             .map(field::isDistinctFrom)
-            .reduce(Condition::and)
-            .orElseThrow(IllegalArgumentException::new);
+            .collect(Collectors.toList()));
       }
     };
   }

--- a/httpql/src/main/java/com/hubspot/httpql/filter/IsDistinctFrom.java
+++ b/httpql/src/main/java/com/hubspot/httpql/filter/IsDistinctFrom.java
@@ -1,0 +1,35 @@
+package com.hubspot.httpql.filter;
+
+import java.util.Collection;
+
+import org.jooq.Condition;
+import org.jooq.Field;
+
+import com.hubspot.httpql.ConditionProvider;
+import com.hubspot.httpql.Filter;
+import com.hubspot.httpql.MultiParamConditionProvider;
+
+public class IsDistinctFrom extends FilterBase implements Filter {
+
+  @Override
+  public String[] names() {
+    return new String[] {
+        "distinct"
+    };
+  }
+
+  @Override
+  public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
+    return new MultiParamConditionProvider<T>(field) {
+
+      @Override
+      public Condition getCondition(Collection<T> values) {
+        return values.stream()
+            .map(field::isDistinctFrom)
+            .reduce(Condition::and)
+            .orElseThrow(IllegalArgumentException::new);
+      }
+
+    };
+  }
+}

--- a/httpql/src/main/java/com/hubspot/httpql/filter/IsNotDistinctFrom.java
+++ b/httpql/src/main/java/com/hubspot/httpql/filter/IsNotDistinctFrom.java
@@ -1,13 +1,11 @@
 package com.hubspot.httpql.filter;
 
-import java.util.Collection;
-
 import org.jooq.Condition;
 import org.jooq.Field;
+import org.jooq.Param;
 
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.Filter;
-import com.hubspot.httpql.MultiParamConditionProvider;
 
 public class IsNotDistinctFrom extends FilterBase implements Filter {
 
@@ -20,14 +18,11 @@ public class IsNotDistinctFrom extends FilterBase implements Filter {
 
   @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
-    return new MultiParamConditionProvider<T>(field) {
+    return new ConditionProvider<T>(field) {
 
       @Override
-      public Condition getCondition(Collection<T> values) {
-        return values.stream()
-            .map(field::isNotDistinctFrom)
-            .reduce(Condition::and)
-            .orElseThrow(IllegalArgumentException::new);
+      public Condition getCondition(Param<T> value) {
+        return field.isNotDistinctFrom(value);
       }
     };
   }

--- a/httpql/src/main/java/com/hubspot/httpql/filter/IsNotDistinctFrom.java
+++ b/httpql/src/main/java/com/hubspot/httpql/filter/IsNotDistinctFrom.java
@@ -9,12 +9,12 @@ import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.Filter;
 import com.hubspot.httpql.MultiParamConditionProvider;
 
-public class IsDistinctFrom extends FilterBase implements Filter {
+public class IsNotDistinctFrom extends FilterBase implements Filter {
 
   @Override
   public String[] names() {
     return new String[] {
-        "distinct"
+        "ndistinct"
     };
   }
 
@@ -25,7 +25,7 @@ public class IsDistinctFrom extends FilterBase implements Filter {
       @Override
       public Condition getCondition(Collection<T> values) {
         return values.stream()
-            .map(field::isDistinctFrom)
+            .map(field::isNotDistinctFrom)
             .reduce(Condition::and)
             .orElseThrow(IllegalArgumentException::new);
       }

--- a/httpql/src/main/resources/META-INF/services/com.hubspot.httpql.Filter
+++ b/httpql/src/main/resources/META-INF/services/com.hubspot.httpql.Filter
@@ -5,6 +5,7 @@ com.hubspot.httpql.filter.GreaterThanOrEqual
 com.hubspot.httpql.filter.In
 com.hubspot.httpql.filter.InsensitiveContains
 com.hubspot.httpql.filter.IsDistinctFrom
+com.hubspot.httpql.filter.IsNotDistinctFrom
 com.hubspot.httpql.filter.LessThan
 com.hubspot.httpql.filter.LessThanOrEqual
 com.hubspot.httpql.filter.NotEqual

--- a/httpql/src/main/resources/META-INF/services/com.hubspot.httpql.Filter
+++ b/httpql/src/main/resources/META-INF/services/com.hubspot.httpql.Filter
@@ -4,6 +4,7 @@ com.hubspot.httpql.filter.GreaterThan
 com.hubspot.httpql.filter.GreaterThanOrEqual
 com.hubspot.httpql.filter.In
 com.hubspot.httpql.filter.InsensitiveContains
+com.hubspot.httpql.filter.IsDistinctFrom
 com.hubspot.httpql.filter.LessThan
 com.hubspot.httpql.filter.LessThanOrEqual
 com.hubspot.httpql.filter.NotEqual

--- a/httpql/src/test/java/com/hubspot/httpql/ParsedQueryTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/ParsedQueryTest.java
@@ -192,7 +192,7 @@ public class ParsedQueryTest {
 
   @Test
   public void itAddsIsNotDistinctFromFilter() {
-    query.put("count__ndistinct", "1,2,3");
+    query.put("count__ndistinct", "1");
     ParsedQuery<Spec> parsed = parser.parse(query);
 
     assertThat(parsed.getBoundFilterEntries()).hasSize(1);

--- a/httpql/src/test/java/com/hubspot/httpql/ParsedQueryTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/ParsedQueryTest.java
@@ -24,6 +24,7 @@ import com.hubspot.httpql.filter.Contains;
 import com.hubspot.httpql.filter.Equal;
 import com.hubspot.httpql.filter.GreaterThan;
 import com.hubspot.httpql.filter.In;
+import com.hubspot.httpql.filter.IsDistinctFrom;
 import com.hubspot.httpql.filter.NotIn;
 import com.hubspot.httpql.filter.NotLike;
 import com.hubspot.httpql.impl.DefaultFieldFactory;
@@ -181,6 +182,15 @@ public class ParsedQueryTest {
   }
 
   @Test
+  public void itAddsIsDisctinctFromFilter() {
+    query.put("count__distinct", "12,100");
+    ParsedQuery<Spec> parsed = parser.parse(query);
+
+    assertThat(parsed.getBoundFilterEntries()).hasSize(1);
+  }
+
+
+  @Test
   public void itaddsOrderBy() {
     query.put("order", "-count");
     ParsedQuery<Spec> parsed = parser.parse(query);
@@ -265,7 +275,7 @@ public class ParsedQueryTest {
     @OrderBy
     @FilterBy(
         value = {
-            GreaterThan.class, Equal.class
+            GreaterThan.class, Equal.class, IsDistinctFrom.class
         })
     Long count;
 

--- a/httpql/src/test/java/com/hubspot/httpql/ParsedQueryTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/ParsedQueryTest.java
@@ -25,6 +25,7 @@ import com.hubspot.httpql.filter.Equal;
 import com.hubspot.httpql.filter.GreaterThan;
 import com.hubspot.httpql.filter.In;
 import com.hubspot.httpql.filter.IsDistinctFrom;
+import com.hubspot.httpql.filter.IsNotDistinctFrom;
 import com.hubspot.httpql.filter.NotIn;
 import com.hubspot.httpql.filter.NotLike;
 import com.hubspot.httpql.impl.DefaultFieldFactory;
@@ -182,13 +183,20 @@ public class ParsedQueryTest {
   }
 
   @Test
-  public void itAddsIsDisctinctFromFilter() {
+  public void itAddsIsDistinctFromFilter() {
     query.put("count__distinct", "12,100");
     ParsedQuery<Spec> parsed = parser.parse(query);
 
     assertThat(parsed.getBoundFilterEntries()).hasSize(1);
   }
 
+  @Test
+  public void itAddsIsNotDistinctFromFilter() {
+    query.put("count__ndistinct", "1,2,3");
+    ParsedQuery<Spec> parsed = parser.parse(query);
+
+    assertThat(parsed.getBoundFilterEntries()).hasSize(1);
+  }
 
   @Test
   public void itaddsOrderBy() {
@@ -275,7 +283,7 @@ public class ParsedQueryTest {
     @OrderBy
     @FilterBy(
         value = {
-            GreaterThan.class, Equal.class, IsDistinctFrom.class
+            GreaterThan.class, Equal.class, IsDistinctFrom.class, IsNotDistinctFrom.class
         })
     Long count;
 


### PR DESCRIPTION
 Currently when we use `not in` or `in` we won't get fields with `NULL` values. This PR adds `isDistinctFrom` to enable queries that return columns with `NULL` values.

See: https://www.jooq.org/javadoc/3.8.x/org/jooq/Field.html#isDistinctFrom-T-