### PR TITLE
Add new OverridableBoundFilterEntry

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/internal/BoundFilterEntry.java
+++ b/httpql/src/main/java/com/hubspot/httpql/internal/BoundFilterEntry.java
@@ -1,7 +1,6 @@
 package com.hubspot.httpql.internal;
 
 import java.util.Collection;
-import java.util.Optional;
 
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -27,7 +26,6 @@ public class BoundFilterEntry<T extends QuerySpec> extends FilterEntry implement
   private final BeanPropertyDefinition prop;
   private final MetaQuerySpec<T> meta;
   private BeanPropertyDefinition actualField;
-  private Optional<Object> value;
 
   public BoundFilterEntry(Filter filter, String fieldName, String queryName, BeanPropertyDefinition prop, MetaQuerySpec<T> meta) {
     super(filter, fieldName, queryName, meta.getQueryType());

--- a/httpql/src/main/java/com/hubspot/httpql/internal/BoundFilterEntry.java
+++ b/httpql/src/main/java/com/hubspot/httpql/internal/BoundFilterEntry.java
@@ -1,6 +1,7 @@
 package com.hubspot.httpql.internal;
 
 import java.util.Collection;
+import java.util.Optional;
 
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -21,11 +22,12 @@ import com.hubspot.httpql.ann.FilterJoin;
 import com.hubspot.httpql.ann.desc.JoinDescriptor;
 import com.hubspot.httpql.impl.DefaultFieldFactory;
 
-public class BoundFilterEntry<T extends QuerySpec>extends FilterEntry implements FilterEntryConditionCreator<T> {
+public class BoundFilterEntry<T extends QuerySpec> extends FilterEntry implements FilterEntryConditionCreator<T> {
 
   private final BeanPropertyDefinition prop;
   private final MetaQuerySpec<T> meta;
   private BeanPropertyDefinition actualField;
+  private Optional<Object> value;
 
   public BoundFilterEntry(Filter filter, String fieldName, String queryName, BeanPropertyDefinition prop, MetaQuerySpec<T> meta) {
     super(filter, fieldName, queryName, meta.getQueryType());
@@ -93,5 +95,4 @@ public class BoundFilterEntry<T extends QuerySpec>extends FilterEntry implements
   public Collection<BoundFilterEntry<T>> getFlattenedBoundFilterEntries() {
     return ImmutableSet.of(this);
   }
-
 }

--- a/httpql/src/main/java/com/hubspot/httpql/internal/MultiValuedBoundFilterEntry.java
+++ b/httpql/src/main/java/com/hubspot/httpql/internal/MultiValuedBoundFilterEntry.java
@@ -7,7 +7,7 @@ import org.jooq.Condition;
 import com.hubspot.httpql.FieldFactory;
 import com.hubspot.httpql.QuerySpec;
 
-public class MultiValuedBoundFilterEntry<T extends QuerySpec>extends BoundFilterEntry<T> {
+public class MultiValuedBoundFilterEntry<T extends QuerySpec> extends BoundFilterEntry<T> {
 
   private final Collection<?> values;
 

--- a/httpql/src/main/java/com/hubspot/httpql/internal/OverridableBoundFilterEntry.java
+++ b/httpql/src/main/java/com/hubspot/httpql/internal/OverridableBoundFilterEntry.java
@@ -1,0 +1,25 @@
+package com.hubspot.httpql.internal;
+
+import org.jooq.Condition;
+
+import com.hubspot.httpql.FieldFactory;
+import com.hubspot.httpql.QuerySpec;
+
+public class OverridableBoundFilterEntry<T extends QuerySpec> extends BoundFilterEntry<T> {
+
+  private final Object value;
+
+  public OverridableBoundFilterEntry(BoundFilterEntry<T> boundFilterEntry, Object value) {
+    super(boundFilterEntry.getFilter(), boundFilterEntry.getProperty(), boundFilterEntry.getMeta());
+    this.value = value;
+  }
+
+  @Override
+  public Condition getCondition(QuerySpec value, FieldFactory fieldFactory) {
+    return getConditionProvider(fieldFactory).getCondition(this.value, getProperty().getName());
+  }
+
+  public Object getValue() {
+    return value;
+  }
+}


### PR DESCRIPTION
The way httpQL is currently setup, it takes the filters and generates BoundFilterEntries from them. This binds all the filters for a query to a single model instance. Meaning that you can't hold more than one value per field. 

This breaks in 2 cases:
- Multi value filters (in, not in, range, etc)
- Combining multiple filters on the same field (e.g. in the case of an OR)

Multi value filters are covered via the [MultiValuedBoundFilterEntry](https://github.com/HubSpot/httpQL/blob/master/httpql/src/main/java/com/hubspot/httpql/internal/MultiValuedBoundFilterEntry.java). This generalizes that approach a bit to a new OverridableBoundFilterEntry.

This is another step to full `OR` support.