### PR TITLE
Support existing behavior for empty-valued query params

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/impl/QueryParser.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/QueryParser.java
@@ -1,5 +1,6 @@
 package com.hubspot.httpql.impl;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -57,6 +58,7 @@ public class QueryParser<T extends QuerySpec> {
   private static final Function<String, String> SNAKE_CASE_TRANSFORMER = input -> CaseFormat.LOWER_CAMEL.to(
       CaseFormat.LOWER_UNDERSCORE, input);
   private static final Set<String> RESERVED_WORDS = ImmutableSet.of("offset", "limit", "order", "includeDeleted");
+  private static final ObjectMapper MAPPER = Rosetta.getMapper().enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
 
   private final Class<T> queryType;
   protected final Collection<String> orderableFields;
@@ -72,7 +74,7 @@ public class QueryParser<T extends QuerySpec> {
   protected QueryParser(final Class<T> spec, boolean strictMode, MetaQuerySpec<T> meta, UriParamParser uriParamParser) {
     this.orderableFields = new ArrayList<>();
     this.queryType = spec;
-    this.mapper = Rosetta.getMapper();
+    this.mapper = MAPPER;
     this.meta = meta;
     this.strictMode = strictMode;
     this.uriParamParser = uriParamParser;
@@ -184,7 +186,7 @@ public class QueryParser<T extends QuerySpec> {
         }
 
         List<?> boundVals = paramVals.stream()
-            .map(v -> Rosetta.getMapper().convertValue(v, convertToType))
+            .map(v -> mapper.convertValue(v, convertToType))
             .collect(Collectors.toList());
 
         boundColumn = new MultiValuedBoundFilterEntry<>(boundColumn, boundVals);

--- a/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserTest.java
@@ -2,6 +2,7 @@ package com.hubspot.httpql.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hubspot.httpql.filter.Null;
 import java.util.Optional;
 
 import org.apache.commons.lang.StringUtils;
@@ -139,6 +140,17 @@ public class QueryParserTest {
     assertThat(offset.get()).isEqualTo(100);
   }
 
+  @Test
+  public void itSupportsEmptyQueryParamValue() {
+    query.put("count__is_null", "");
+    query.put("fullName", "");
+
+    Spec spec = parser.parse(query).getBoundQuery();
+
+    assertThat(spec.getCount()).isNull();
+    assertThat(spec.getFullName()).isEqualTo("");
+  }
+
   @QueryConstraints(defaultLimit = 10, maxLimit = 100, maxOffset = 100)
   @RosettaNaming(SnakeCaseStrategy.class)
   public static class Spec implements QuerySpec {
@@ -148,7 +160,7 @@ public class QueryParserTest {
     })
     Integer id;
 
-    @FilterBy(GreaterThan.class)
+    @FilterBy({GreaterThan.class, Null.class})
     Long count;
 
     @FilterBy(Equal.class)


### PR DESCRIPTION
#### Description

Enables deserialization of `Null` and `NotNull` query parameters, when used for non-string properties.