### PR TITLE
Handle filters that do not require a value

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/impl/QueryParser.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/QueryParser.java
@@ -60,7 +60,6 @@ public class QueryParser<T extends QuerySpec> {
   private static final Function<String, String> SNAKE_CASE_TRANSFORMER = input -> CaseFormat.LOWER_CAMEL.to(
       CaseFormat.LOWER_UNDERSCORE, input);
   private static final Set<String> RESERVED_WORDS = ImmutableSet.of("offset", "limit", "order", "includeDeleted");
-  private static final ObjectMapper MAPPER = Rosetta.getMapper().enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);
 
   private final Class<T> queryType;
   protected final Collection<String> orderableFields;
@@ -76,7 +75,7 @@ public class QueryParser<T extends QuerySpec> {
   protected QueryParser(final Class<T> spec, boolean strictMode, MetaQuerySpec<T> meta, UriParamParser uriParamParser) {
     this.orderableFields = new ArrayList<>();
     this.queryType = spec;
-    this.mapper = MAPPER;
+    this.mapper = Rosetta.getMapper();
     this.meta = meta;
     this.strictMode = strictMode;
     this.uriParamParser = uriParamParser;

--- a/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserTest.java
@@ -2,6 +2,8 @@ package com.hubspot.httpql.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.hubspot.httpql.filter.NotNull;
+import com.hubspot.httpql.filter.Null;
 import java.util.Optional;
 
 import org.apache.commons.lang.StringUtils;
@@ -139,12 +141,26 @@ public class QueryParserTest {
     assertThat(offset.get()).isEqualTo(100);
   }
 
+  @Test
+  public void itBindsDefaultValueForNullFilter() {
+    query.put("id__is_null", "1");
+    Spec spec = parser.parse(query).getBoundQuery();
+    assertThat(spec.getId()).isNull();
+  }
+
+  @Test
+  public void itBindsDefaultValueForNotNullFilter() {
+    query.put("id__not_null", "1");
+    Spec spec = parser.parse(query).getBoundQuery();
+    assertThat(spec.getId()).isNull();
+  }
+
   @QueryConstraints(defaultLimit = 10, maxLimit = 100, maxOffset = 100)
   @RosettaNaming(SnakeCaseStrategy.class)
   public static class Spec implements QuerySpec {
 
     @FilterBy({
-        Equal.class, In.class
+        Equal.class, In.class, Null.class, NotNull.class
     })
     Integer id;
 

--- a/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserTest.java
@@ -143,14 +143,14 @@ public class QueryParserTest {
 
   @Test
   public void itBindsDefaultValueForNullFilter() {
-    query.put("id__is_null", "1");
+    query.put("id__is_null", " ");
     Spec spec = parser.parse(query).getBoundQuery();
     assertThat(spec.getId()).isNull();
   }
 
   @Test
   public void itBindsDefaultValueForNotNullFilter() {
-    query.put("id__not_null", "1");
+    query.put("id__not_null", " ");
     Spec spec = parser.parse(query).getBoundQuery();
     assertThat(spec.getId()).isNull();
   }


### PR DESCRIPTION
#### Description

Ignore query parameter value for `Null` and `NotNull` filters. 
Supports backwards compatibility for " " to be used as query parameter values for `__is_null` and `__not_null`.