### PR TITLE
Bump jooq version

### DIFF
--- a/httpql-jersey1/pom.xml
+++ b/httpql-jersey1/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot.httpql</groupId>
     <artifactId>httpql-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1</version>
   </parent>
 
   <artifactId>httpql-jersey1</artifactId>

--- a/httpql/pom.xml
+++ b/httpql/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot.httpql</groupId>
     <artifactId>httpql-parent</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1</version>
   </parent>
 
   <artifactId>httpql</artifactId>

--- a/httpql/src/test/java/com/hubspot/httpql/SelectBuilderTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/SelectBuilderTest.java
@@ -53,7 +53,7 @@ public class SelectBuilderTest {
     query.put("offset", "5");
 
     parsed = parser.parse(query);
-    queryFormat = "select * from example where (`comments` not like %s escape '!' and `comments` not like %s escape '!' and `id` in (%s, %s) and `count` > %s and `full_name` = %s) limit %s offset %s";
+    queryFormat = "select * from example where (`comments` not like %s escape '!' and `comments` not like %s escape '!' and `count` > %s and `id` in (%s, %s) and `full_name` = %s) limit %s offset %s";
   }
 
   @Test
@@ -113,7 +113,7 @@ public class SelectBuilderTest {
 
     String sql = selectBuilder.build().toString();
 
-    assertThat(sql).isEqualTo(String.format(queryFormat, ":1", ":2", ":3", ":4", ":count", ":full_name", ":7", ":8"));
+    assertThat(sql).isEqualTo(String.format(queryFormat, ":1", ":2", ":count", ":4", ":5", ":full_name", ":7", ":8"));
   }
 
   @Test
@@ -122,7 +122,7 @@ public class SelectBuilderTest {
 
     String sql = selectBuilder.build().toString();
 
-    assertThat(sql).isEqualTo(String.format(queryFormat, "'%John%'", "'Jane%'", "1", "2", "100", "'example'", "10", "5"));
+    assertThat(sql).isEqualTo(String.format(queryFormat, "'%John%'", "'Jane%'", "100", "1", "2", "'example'", "10", "5"));
   }
 
   @Test
@@ -143,7 +143,7 @@ public class SelectBuilderTest {
     String sql = selectBuilder.build().toString();
 
     assertThat(sql).startsWith(
-        "select id as `a.id`, full_name as `a.full_name` from example where (`a.comments` not like '%John%' escape '!' and `a.comments` not like 'Jane%' escape '!' and `a.id`");
+        "select id as `a.id`, full_name as `a.full_name` from example where (`a.comments` not like '%John%' escape '!' and `a.comments` not like 'Jane%' escape '!' and `a.count` > 100 and `a.id`");
   }
 
   @Test
@@ -155,7 +155,7 @@ public class SelectBuilderTest {
     String sql = selectBuilder.build().toString();
 
     assertThat(sql).startsWith(
-        "select `example`.`id`, `example`.`full_name` from example where (`example`.`comments` not like '%John%' escape '!' and `example`.`comments` not like 'Jane%' escape '!' and `example`.`id`");
+        "select `example`.`id`, `example`.`full_name` from example where (`example`.`comments` not like '%John%' escape '!' and `example`.`comments` not like 'Jane%' escape '!' and `example`.`count` > 100 and `example`.`id`");
   }
 
   @Test
@@ -166,7 +166,7 @@ public class SelectBuilderTest {
     String sql = selectBuilder.build().toString();
 
     assertThat(sql).isEqualTo(
-        "select count(*) from example where (`comments` not like ? escape '!' and `comments` not like ? escape '!' and `id` in (?, ?) and `count` > ? and `full_name` = ?)");
+        "select count(*) from example where (`comments` not like ? escape '!' and `comments` not like ? escape '!' and `count` > ? and `id` in (?, ?) and `full_name` = ?)");
   }
 
   @Test

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.hubspot.httpql</groupId>
   <artifactId>httpql-parent</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>1.0.1</version>
   <packaging>pom</packaging>
 
   <description>A library that exposes SELECT queries through HTTP query parameters.</description>
@@ -58,7 +58,78 @@
     </dependencies>
   </dependencyManagement>
 
+
   <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.basepom.maven</groupId>
+          <artifactId>duplicate-finder-maven-plugin</artifactId>
+          <configuration>
+            <exceptions combine.children="append">
+              <!-- Well done, Apache... -->
+              <exception>
+                <conflictingDependencies>
+                  <dependency>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils</artifactId>
+                  </dependency>
+                  <dependency>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils-core</artifactId>
+                  </dependency>
+                  <dependency>
+                    <groupId>commons-collections</groupId>
+                    <artifactId>commons-collections</artifactId>
+                  </dependency>
+                </conflictingDependencies>
+                <classes>
+                  <class>org.apache.commons.collections.ArrayStack</class>
+                  <class>org.apache.commons.collections.Buffer</class>
+                  <class>org.apache.commons.collections.BufferUnderflowException</class>
+                  <class>org.apache.commons.collections.FastHashMap</class>
+                </classes>
+              </exception>
+              <exception>
+                <conflictingDependencies>
+                  <dependency>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils</artifactId>
+                  </dependency>
+                  <dependency>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils-core</artifactId>
+                  </dependency>
+                </conflictingDependencies>
+                <packages>
+                  <package>org.apache.commons.beanutils</package>
+                </packages>
+              </exception>
+            </exceptions>
+            <!-- Ruby is hopeless -->
+            <ignoredDependencies>
+              <dependency>
+                <groupId>org.jruby</groupId>
+                <artifactId>jruby-complete</artifactId>
+              </dependency>
+              <dependency>
+                <groupId>org.jooq</groupId>
+                <artifactId>jooq</artifactId>
+              </dependency>
+              <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+              </dependency>
+            </ignoredDependencies>
+            <ignoredClassPatterns>
+              <!-- Can remove once https://github.com/basepom/duplicate-finder-maven-plugin/issues/33 is fixed -->
+              <ignoredClassPattern>^META-INF.versions.9.module-info$</ignoredClassPattern>
+            </ignoredClassPatterns>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
     <plugins>
       <plugin>
         <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>com.hubspot</groupId>
     <artifactId>basepom</artifactId>
-    <version>25.4</version>
+    <version>25.7</version>
   </parent>
 
   <groupId>com.hubspot.httpql</groupId>
@@ -21,6 +21,9 @@
   </modules>
 
   <properties>
+    <project.build.targetJdk>11</project.build.targetJdk>
+    <project.build.sourceJdk>11</project.build.sourceJdk>
+    <project.build.releaseJdk>11</project.build.releaseJdk>
     <basepom.check.skip-findbugs>true</basepom.check.skip-findbugs>
   </properties>
 
@@ -50,7 +53,7 @@
       <dependency>
         <groupId>org.jooq</groupId>
         <artifactId>jooq</artifactId>
-        <version>3.7.2</version>
+        <version>3.15.5</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Bumping jooq to 3.15.2. It seems like the only behaviour that changed (and were caught by unit tests) is how fields are ordered in the where clauses. 

Starting from jooq-3.15, [jooq only works with Java 11](https://stackoverflow.com/questions/71561604/jooq-throws-class-file-for-java-util-concurrent-flow-not-found-for-where-conditi) so we should probably bump 1.0.0-SNAPSHOT and make a proper release as this could break users of this library.