### PR TITLE
Bump duplicate-finder-maven-plugin to 1.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,22 @@
   </dependencyManagement>
 
   <build>
+    <pluginManagement>
+      <plugins>
+        <!--
+          Overriding from 1.2.1 provided by basepom.
+          This is to prevent issues with module-info being flagged as a duplicate class
+
+          [WARNING] Found duplicate and different classes in [javax.xml.bind:jaxb-api:2.3.1, org.jooq:jooq:3.15.5]:
+          [WARNING]   module-info
+        -->
+        <plugin>
+          <groupId>org.basepom.maven</groupId>
+          <artifactId>duplicate-finder-maven-plugin</artifactId>
+          <version>1.3.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.jacoco</groupId>


### PR DESCRIPTION
Since we bumped the version of jooq in #23, it looks like we're experiencing an unexpected breakage in `duplicate-finder-maven-plugin`. Since that's running a pretty old version by default in basepom, it doesn't perform some checks we'd expect/require (including skipping `module-info` entries). This PR tries bumping the version of that plugin to fix our build

cc @csokol @jhaber 