### PR TITLE
Avoid using deprecated method

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/ConditionProvider.java
+++ b/httpql/src/main/java/com/hubspot/httpql/ConditionProvider.java
@@ -25,9 +25,7 @@ public abstract class ConditionProvider<T> {
   }
 
   public Param<T> getParam(Object value, String paramName) {
-    Param<T> param = DSL.param(paramName, field.getType());
-    param.setConverted(value);
-    return param;
+    return (Param<T>) DSL.val(value);
   }
 
   public Condition getCondition(Object value, String paramName) {


### PR DESCRIPTION
I'm not 100% sure about what's the point of this method (besides bypassing generics checks). It creates a Param and sets its value right away, so I believe we can simply replace with DSL.value which seems equivalent.

This solves the deprecation warning that pollutes all httpql users' logs.