### PR TITLE
Revert "Avoid using deprecated method"

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/ConditionProvider.java
+++ b/httpql/src/main/java/com/hubspot/httpql/ConditionProvider.java
@@ -25,7 +25,9 @@ public abstract class ConditionProvider<T> {
   }
 
   public Param<T> getParam(Object value, String paramName) {
-    return (Param<T>) DSL.val(value);
+    Param<T> param = DSL.param(paramName, field.getType());
+    param.setConverted(value);
+    return param;
   }
 
   public Condition getCondition(Object value, String paramName) {


### PR DESCRIPTION
Reverts HubSpot/httpQL#25

The PR broke the build as the lib uses ConditionProvider to create named parameters and there was a small change on how value types are converted (looks like integer/long values are sometimes converted to strings). I'll address the deprecation issue in follow up PR.