### PR TITLE
Remove deprecated method usage

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/ConditionProvider.java
+++ b/httpql/src/main/java/com/hubspot/httpql/ConditionProvider.java
@@ -25,9 +25,7 @@ public abstract class ConditionProvider<T> {
   }
 
   public Param<T> getParam(Object value, String paramName) {
-    Param<T> param = DSL.param(paramName, field.getType());
-    param.setConverted(value);
-    return param;
+    return DSL.param(paramName, field.getType().cast(value));
   }
 
   public Condition getCondition(Object value, String paramName) {

--- a/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserComplexJoinDescriptorTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserComplexJoinDescriptorTest.java
@@ -1,16 +1,15 @@
 package com.hubspot.httpql.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.hubspot.httpql.ParsedQuery;
+import com.hubspot.httpql.model.EntityWithComplexJoinDescriptor;
 import org.apache.commons.lang.StringUtils;
 import org.jooq.SelectFinalStep;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-import com.hubspot.httpql.ParsedQuery;
-import com.hubspot.httpql.model.EntityWithComplexJoinDescriptor;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class QueryParserComplexJoinDescriptorTest {
 
@@ -40,7 +39,7 @@ public class QueryParserComplexJoinDescriptorTest {
             + "`entity_table`.`group_id` = `join_tbl`.`id` "
             + "and `entity_table`.`tag` = `join_tbl`.`id` "
             + "and `join_tbl`.`meta_type` = 'joinObjects' ) "
-            + "where ifnull(`join_tbl`.`topic_id`, 0) = '123' "
+            + "where ifnull(`join_tbl`.`topic_id`, 0) = 123 "
             + "limit 10");
   }
 

--- a/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserJoinTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserJoinTest.java
@@ -1,16 +1,15 @@
 package com.hubspot.httpql.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.hubspot.httpql.ParsedQuery;
+import com.hubspot.httpql.model.EntityWithSimpleJoin;
 import org.apache.commons.lang.StringUtils;
 import org.jooq.SelectFinalStep;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-import com.hubspot.httpql.ParsedQuery;
-import com.hubspot.httpql.model.EntityWithSimpleJoin;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class QueryParserJoinTest {
 
@@ -37,7 +36,7 @@ public class QueryParserJoinTest {
     assertThat(StringUtils.normalizeSpace(sql.toString()))
         .isEqualTo("select distinct entity_table.* from entity_table "
             + "join `join_tbl` on `entity_table`.`id` = `join_tbl`.`entity_id` "
-            + "where `join_tbl`.`topic_id` = '123' limit 10");
+            + "where `join_tbl`.`topic_id` = 123 limit 10");
   }
 
   @Test

--- a/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserSimpleJoinDescriptorTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserSimpleJoinDescriptorTest.java
@@ -1,16 +1,15 @@
 package com.hubspot.httpql.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.hubspot.httpql.ParsedQuery;
+import com.hubspot.httpql.model.EntityWithSimpleJoinDescriptor;
 import org.apache.commons.lang.StringUtils;
 import org.jooq.SelectFinalStep;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-import com.hubspot.httpql.ParsedQuery;
-import com.hubspot.httpql.model.EntityWithSimpleJoinDescriptor;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class QueryParserSimpleJoinDescriptorTest {
 
@@ -37,7 +36,7 @@ public class QueryParserSimpleJoinDescriptorTest {
     assertThat(StringUtils.normalizeSpace(sql.toString()))
         .isEqualTo("select distinct entity_table.* from entity_table "
             + "join `join_tbl` on `entity_table`.`id` = `join_tbl`.`entity_id` "
-            + "where `join_tbl`.`topic_id` = '123' limit 10");
+            + "where `join_tbl`.`topic_id` = 123 limit 10");
   }
 
   @Test


### PR DESCRIPTION
As my attempt in #25 broke the usage of named parameters, I'm trying to address the issue here again.

The closest thing I could find to the previous code was `DSL.param(paramName, (T) value)` but it looks like it causes a small change in behaviour. The previous code was for some reason turning long parameters into string values (for example `join_tbl.topic_id = '123'` instead of `join_tbl.topic_id = 123`). The new behaviour seems more accurate to be honest but it looks like this could be a breaking change?

I also think querying a number field by string could also cause indexes not be used. I think I've seen this in the past for MSSQL, the query above would cause a full table scan even if topic_id had an index because all the values would be converted to varchar first. IDK if the same happens for mysql.