### PR TITLE
Revert "Remove deprecated method usage"

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/ConditionProvider.java
+++ b/httpql/src/main/java/com/hubspot/httpql/ConditionProvider.java
@@ -25,7 +25,9 @@ public abstract class ConditionProvider<T> {
   }
 
   public Param<T> getParam(Object value, String paramName) {
-    return DSL.param(paramName, field.getType().cast(value));
+    Param<T> param = DSL.param(paramName, field.getType());
+    param.setConverted(value);
+    return param;
   }
 
   public Condition getCondition(Object value, String paramName) {

--- a/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserComplexJoinDescriptorTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserComplexJoinDescriptorTest.java
@@ -1,15 +1,16 @@
 package com.hubspot.httpql.impl;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-import com.hubspot.httpql.ParsedQuery;
-import com.hubspot.httpql.model.EntityWithComplexJoinDescriptor;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.commons.lang.StringUtils;
 import org.jooq.SelectFinalStep;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.hubspot.httpql.ParsedQuery;
+import com.hubspot.httpql.model.EntityWithComplexJoinDescriptor;
 
 public class QueryParserComplexJoinDescriptorTest {
 
@@ -39,7 +40,7 @@ public class QueryParserComplexJoinDescriptorTest {
             + "`entity_table`.`group_id` = `join_tbl`.`id` "
             + "and `entity_table`.`tag` = `join_tbl`.`id` "
             + "and `join_tbl`.`meta_type` = 'joinObjects' ) "
-            + "where ifnull(`join_tbl`.`topic_id`, 0) = 123 "
+            + "where ifnull(`join_tbl`.`topic_id`, 0) = '123' "
             + "limit 10");
   }
 

--- a/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserJoinTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserJoinTest.java
@@ -1,15 +1,16 @@
 package com.hubspot.httpql.impl;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-import com.hubspot.httpql.ParsedQuery;
-import com.hubspot.httpql.model.EntityWithSimpleJoin;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.commons.lang.StringUtils;
 import org.jooq.SelectFinalStep;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.hubspot.httpql.ParsedQuery;
+import com.hubspot.httpql.model.EntityWithSimpleJoin;
 
 public class QueryParserJoinTest {
 
@@ -36,7 +37,7 @@ public class QueryParserJoinTest {
     assertThat(StringUtils.normalizeSpace(sql.toString()))
         .isEqualTo("select distinct entity_table.* from entity_table "
             + "join `join_tbl` on `entity_table`.`id` = `join_tbl`.`entity_id` "
-            + "where `join_tbl`.`topic_id` = 123 limit 10");
+            + "where `join_tbl`.`topic_id` = '123' limit 10");
   }
 
   @Test

--- a/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserSimpleJoinDescriptorTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserSimpleJoinDescriptorTest.java
@@ -1,15 +1,16 @@
 package com.hubspot.httpql.impl;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Multimap;
-import com.hubspot.httpql.ParsedQuery;
-import com.hubspot.httpql.model.EntityWithSimpleJoinDescriptor;
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.apache.commons.lang.StringUtils;
 import org.jooq.SelectFinalStep;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import com.hubspot.httpql.ParsedQuery;
+import com.hubspot.httpql.model.EntityWithSimpleJoinDescriptor;
 
 public class QueryParserSimpleJoinDescriptorTest {
 
@@ -36,7 +37,7 @@ public class QueryParserSimpleJoinDescriptorTest {
     assertThat(StringUtils.normalizeSpace(sql.toString()))
         .isEqualTo("select distinct entity_table.* from entity_table "
             + "join `join_tbl` on `entity_table`.`id` = `join_tbl`.`entity_id` "
-            + "where `join_tbl`.`topic_id` = 123 limit 10");
+            + "where `join_tbl`.`topic_id` = '123' limit 10");
   }
 
   @Test


### PR DESCRIPTION
Reverts HubSpot/httpQL#27

Reverting this as it caused some build issues internally. Might have to come back to it and maybe release a new version of the library with this change.