### PR TITLE
Upgrade jackson version + add condition on PropertyNamingStrategies.SnakeCaseStrategy

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/DefaultMetaUtils.java
+++ b/httpql/src/main/java/com/hubspot/httpql/DefaultMetaUtils.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
@@ -81,7 +82,8 @@ public class DefaultMetaUtils {
 
     boolean snakeCasing = rosettaNaming != null &&
         (rosettaNaming.value().equals(LowerCaseWithUnderscoresStrategy.class) ||
-            rosettaNaming.value().equals(SnakeCaseStrategy.class));
+            rosettaNaming.value().equals(SnakeCaseStrategy.class) ||
+                rosettaNaming.value().equals(PropertyNamingStrategies.SnakeCaseStrategy.class));
 
     if (snakeCasing && !name.contains("_")) {
       return CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, name);

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,8 @@
     <project.build.sourceJdk>11</project.build.sourceJdk>
     <project.build.releaseJdk>11</project.build.releaseJdk>
     <basepom.check.skip-findbugs>true</basepom.check.skip-findbugs>
+    <dep.jackson.version>2.12.6</dep.jackson.version>
+    <dep.jackson-databind.version>${dep.jackson.version}</dep.jackson-databind.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This condition is required to migrate downstream dependencies to `PropertyNamingStrategies` constants and strategy implementations. 

The `PropertyNamingStrategies` class was introduced in 2.12, so the changes also include a version update for the repo - without making changes to basepom.

A search shows no repos in the org's github that use httpQL, and my understanding is that other downstream repos in `git.hubteam` inherit from parent-pom, which is on this updated version.