### PR TITLE
map legacy and new filters

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/Filter.java
+++ b/httpql/src/main/java/com/hubspot/httpql/Filter.java
@@ -1,5 +1,6 @@
 package com.hubspot.httpql;
 
+import com.hubspot.httpql.core.filter.FilterIF;
 import org.jooq.Field;
 
 /**
@@ -7,7 +8,7 @@ import org.jooq.Field;
  *
  * @author tdavis
  */
-public interface Filter {
+public interface Filter extends FilterIF {
   /**
    * List of names the operator goes by in queries; the {@code gt} in {@code foo_gt=1}
    */

--- a/httpql/src/main/java/com/hubspot/httpql/Filters.java
+++ b/httpql/src/main/java/com/hubspot/httpql/Filters.java
@@ -23,11 +23,11 @@ public class Filters {
             }
         }
 
-        for (FilterImpl filter : FILTER_IMPL_LOADER) {
-            for (String name : filter.names()) {
-                FILTER_IMPLS_BY_NAME.put(name, filter);
+        for (FilterImpl filterImpl : FILTER_IMPL_LOADER) {
+            for (String name : filterImpl.names()) {
+                FILTER_IMPLS_BY_NAME.put(name, filterImpl);
             }
-            FILTER_IMPLS.put(filter.getAnnotationClass(), filter);
+            filterImpl.getAnnotationClasses().forEach(f -> FILTER_IMPLS.put(f, filterImpl));
         }
     }
 

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/ContainsImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/ContainsImpl.java
@@ -1,11 +1,14 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.core.filter.Contains;
 import com.hubspot.httpql.core.filter.FilterIF;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Param;
+
+import java.util.Set;
 
 public class ContainsImpl extends FilterBase implements FilterImpl {
 
@@ -29,8 +32,8 @@ public class ContainsImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return Contains.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(Contains.class, com.hubspot.httpql.filter.Contains.class);
   }
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/EqualImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/EqualImpl.java
@@ -1,11 +1,14 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.core.filter.Equal;
 import com.hubspot.httpql.core.filter.FilterIF;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Param;
+
+import java.util.Set;
 
 public class EqualImpl extends FilterBase implements FilterImpl {
 
@@ -29,8 +32,8 @@ public class EqualImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return Equal.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(Equal.class, com.hubspot.httpql.filter.Equal.class);
   }
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/FilterImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/FilterImpl.java
@@ -4,6 +4,8 @@ import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import org.jooq.Field;
 
+import java.util.Set;
+
 /**
  * Effectively the operator in a WHERE clause condition.
  *
@@ -17,6 +19,6 @@ public interface FilterImpl {
 
   <T> ConditionProvider<T> getConditionProvider(Field<T> field);
 
-  Class<? extends FilterIF> getAnnotationClass();
+  Set<Class<? extends FilterIF>> getAnnotationClasses();
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/GreaterThanImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/GreaterThanImpl.java
@@ -1,11 +1,14 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import com.hubspot.httpql.core.filter.GreaterThan;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Param;
+
+import java.util.Set;
 
 public class GreaterThanImpl extends FilterBase implements FilterImpl {
 
@@ -29,8 +32,8 @@ public class GreaterThanImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return GreaterThan.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(GreaterThan.class, com.hubspot.httpql.filter.GreaterThan.class);
   }
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/GreaterThanOrEqualImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/GreaterThanOrEqualImpl.java
@@ -1,11 +1,14 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import com.hubspot.httpql.core.filter.GreaterThanOrEqual;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Param;
+
+import java.util.Set;
 
 public class GreaterThanOrEqualImpl extends FilterBase implements FilterImpl {
 
@@ -27,10 +30,9 @@ public class GreaterThanOrEqualImpl extends FilterBase implements FilterImpl {
 
     };
   }
-
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return GreaterThanOrEqual.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(GreaterThanOrEqual.class, com.hubspot.httpql.filter.GreaterThanOrEqual.class);
   }
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/InImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/InImpl.java
@@ -1,12 +1,15 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.MultiParamConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import com.hubspot.httpql.core.filter.In;
-import java.util.Collection;
 import org.jooq.Condition;
 import org.jooq.Field;
+
+import java.util.Collection;
+import java.util.Set;
 
 public class InImpl extends FilterBase implements FilterImpl {
 
@@ -30,8 +33,8 @@ public class InImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return In.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(In.class, com.hubspot.httpql.filter.In.class);
   }
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/InsensitiveContainsImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/InsensitiveContainsImpl.java
@@ -1,5 +1,6 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.google.common.escape.Escaper;
 import com.google.common.escape.Escapers;
 import com.hubspot.httpql.ConditionProvider;
@@ -8,6 +9,8 @@ import com.hubspot.httpql.core.filter.InsensitiveContains;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Param;
+
+import java.util.Set;
 
 public class InsensitiveContainsImpl extends FilterBase implements FilterImpl {
   private static final Escaper ESCAPER = Escapers.builder()
@@ -39,8 +42,8 @@ public class InsensitiveContainsImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return InsensitiveContains.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(InsensitiveContains.class, com.hubspot.httpql.filter.InsensitiveContains.class);
   }
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/IsDistinctFromImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/IsDistinctFromImpl.java
@@ -1,14 +1,17 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.MultiParamConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import com.hubspot.httpql.core.filter.IsDistinctFrom;
-import java.util.Collection;
-import java.util.stream.Collectors;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.impl.DSL;
+
+import java.util.Collection;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class IsDistinctFromImpl extends FilterBase implements FilterImpl {
 
@@ -33,7 +36,7 @@ public class IsDistinctFromImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return IsDistinctFrom.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(IsDistinctFrom.class, com.hubspot.httpql.filter.IsDistinctFrom.class);
   }
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/IsNotDistinctFromImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/IsNotDistinctFromImpl.java
@@ -1,11 +1,14 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import com.hubspot.httpql.core.filter.IsNotDistinctFrom;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Param;
+
+import java.util.Set;
 
 public class IsNotDistinctFromImpl extends FilterBase implements FilterImpl {
 
@@ -28,7 +31,7 @@ public class IsNotDistinctFromImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return IsNotDistinctFrom.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(IsNotDistinctFrom.class, com.hubspot.httpql.filter.IsNotDistinctFrom.class);
   }
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/LessThanImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/LessThanImpl.java
@@ -1,11 +1,14 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import com.hubspot.httpql.core.filter.LessThan;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Param;
+
+import java.util.Set;
 
 public class LessThanImpl extends FilterBase implements FilterImpl {
 
@@ -29,8 +32,8 @@ public class LessThanImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return LessThan.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(LessThan.class, com.hubspot.httpql.filter.LessThan.class);
   }
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/LessThanOrEqualImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/LessThanOrEqualImpl.java
@@ -1,11 +1,14 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import com.hubspot.httpql.core.filter.LessThanOrEqual;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Param;
+
+import java.util.Set;
 
 public class LessThanOrEqualImpl extends FilterBase implements FilterImpl {
 
@@ -29,8 +32,8 @@ public class LessThanOrEqualImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return LessThanOrEqual.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(LessThanOrEqual.class, com.hubspot.httpql.filter.LessThanOrEqual.class);
   }
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotEqualImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotEqualImpl.java
@@ -1,11 +1,14 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import com.hubspot.httpql.core.filter.NotEqual;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Param;
+
+import java.util.Set;
 
 public class NotEqualImpl extends FilterBase implements FilterImpl {
 
@@ -29,8 +32,8 @@ public class NotEqualImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return NotEqual.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(NotEqual.class, com.hubspot.httpql.filter.NotEqual.class);
   }
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotInImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotInImpl.java
@@ -1,12 +1,15 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.MultiParamConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import com.hubspot.httpql.core.filter.NotIn;
-import java.util.Collection;
 import org.jooq.Condition;
 import org.jooq.Field;
+
+import java.util.Collection;
+import java.util.Set;
 
 public class NotInImpl extends FilterBase implements FilterImpl {
 
@@ -30,8 +33,8 @@ public class NotInImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return NotIn.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(NotIn.class, com.hubspot.httpql.filter.NotIn.class);
   }
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotLikeImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotLikeImpl.java
@@ -1,13 +1,16 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.MultiParamConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import com.hubspot.httpql.core.filter.NotLike;
-import java.util.Collection;
-import java.util.Iterator;
 import org.jooq.Condition;
 import org.jooq.Field;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
 
 public class NotLikeImpl extends FilterBase implements FilterImpl {
 
@@ -36,8 +39,8 @@ public class NotLikeImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return NotLike.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(NotLike.class, com.hubspot.httpql.filter.NotLike.class);
   }
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotNullImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotNullImpl.java
@@ -1,11 +1,14 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import com.hubspot.httpql.core.filter.NotNull;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Param;
+
+import java.util.Set;
 
 public class NotNullImpl extends FilterBase implements FilterImpl {
   @Override
@@ -27,7 +30,7 @@ public class NotNullImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return NotNull.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(NotNull.class, com.hubspot.httpql.filter.NotNull.class);
   }
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/NullImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/NullImpl.java
@@ -1,11 +1,14 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import com.hubspot.httpql.core.filter.Null;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Param;
+
+import java.util.Set;
 
 public class NullImpl extends FilterBase implements FilterImpl {
   @Override
@@ -27,7 +30,7 @@ public class NullImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return Null.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(Null.class, com.hubspot.httpql.filter.Null.class);
   }
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/RangeImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/RangeImpl.java
@@ -1,18 +1,21 @@
 package com.hubspot.httpql.impl.filter;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.MultiParamConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import com.hubspot.httpql.core.filter.Range;
+import org.jooq.Condition;
+import org.jooq.Field;
+
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import org.jooq.Condition;
-import org.jooq.Field;
+import java.util.Set;
 
 public class RangeImpl extends FilterBase implements FilterImpl {
 
@@ -46,10 +49,9 @@ public class RangeImpl extends FilterBase implements FilterImpl {
 
     };
   }
-
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return Range.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(Range.class, com.hubspot.httpql.filter.Range.class);
   }
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/StartsWithImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/StartsWithImpl.java
@@ -1,11 +1,14 @@
 package com.hubspot.httpql.impl.filter;
 
+import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.core.filter.FilterIF;
 import com.hubspot.httpql.core.filter.StartsWith;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Param;
+
+import java.util.Set;
 
 public class StartsWithImpl extends FilterBase implements FilterImpl {
 
@@ -29,8 +32,8 @@ public class StartsWithImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Class<? extends FilterIF> getAnnotationClass() {
-    return StartsWith.class;
+  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+    return ImmutableSet.of(StartsWith.class, com.hubspot.httpql.filter.StartsWith.class);
   }
 
 }


### PR DESCRIPTION
We can save ourselves some migration work later if we can map the legacy filters to the new FilterImpls directly without having to instantiate one and look it up by name.

Now we can look up FilterImpls by either the old or new classes.