### PR TITLE
add some filter methods back

### DIFF
--- a/httpql-core/src/main/java/com/hubspot/httpql/core/FilterEntry.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/FilterEntry.java
@@ -5,7 +5,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnders
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.google.common.base.CaseFormat;
 import com.google.common.base.Objects;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.rosetta.annotations.RosettaNaming;
 import java.lang.annotation.Annotation;
 import java.util.Optional;
@@ -14,13 +14,13 @@ public class FilterEntry {
 
   private final String queryName;
   private final String fieldName;
-  private final FilterIF filter;
+  private final Filter filter;
 
-  public FilterEntry(FilterIF filter, String queryName, Class<?> queryType) { // Only valid for comparison
+  public FilterEntry(Filter filter, String queryName, Class<?> queryType) { // Only valid for comparison
     this(filter, queryName, queryName, queryType);
   }
 
-  public FilterEntry(FilterIF filter, String fieldName, String queryName, Class<?> queryType) {
+  public FilterEntry(Filter filter, String fieldName, String queryName, Class<?> queryType) {
     this.filter = filter;
     this.fieldName = fieldName;
     this.queryName = convertToSnakeCaseIfSupported(queryName, queryType);
@@ -34,12 +34,12 @@ public class FilterEntry {
     return fieldName;
   }
 
-  public FilterIF getFilter() {
+  public Filter getFilter() {
     return filter;
   }
 
-  public Optional<Class<? extends FilterIF>> getFilterClassMaybe() {
-    return Optional.ofNullable(filter).map(FilterIF::getClass);
+  public Optional<Class<? extends Filter>> getFilterClassMaybe() {
+    return Optional.ofNullable(filter).map(Filter::getClass);
   }
 
   @Override

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/ann/FilterBy.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/ann/FilterBy.java
@@ -1,6 +1,6 @@
 package com.hubspot.httpql.core.ann;
 
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
     ElementType.FIELD, ElementType.METHOD
 })
 public @interface FilterBy {
-  Class<? extends FilterIF>[] value();
+  Class<? extends Filter>[] value();
 
   String as() default "";
 

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/Contains.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/Contains.java
@@ -2,7 +2,6 @@ package com.hubspot.httpql.core.filter;
 
 public class Contains implements Filter {
 
-
     @Override
     public String[] names() {
         return new String[] {

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/Contains.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/Contains.java
@@ -1,5 +1,12 @@
 package com.hubspot.httpql.core.filter;
 
-public class Contains implements FilterIF {
+public class Contains implements Filter {
 
+
+    @Override
+    public String[] names() {
+        return new String[] {
+                "contains", "like"
+        };
+    }
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/Equal.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/Equal.java
@@ -1,7 +1,6 @@
 package com.hubspot.httpql.core.filter;
 
 public class Equal implements Filter {
-
     @Override
     public String[] names() {
         return new String[] {

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/Equal.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/Equal.java
@@ -1,6 +1,12 @@
 package com.hubspot.httpql.core.filter;
 
-public class Equal implements FilterIF {
+public class Equal implements Filter {
 
+    @Override
+    public String[] names() {
+        return new String[] {
+                "eq", "exact", "is"
+        };
+    }
 
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/Filter.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/Filter.java
@@ -3,7 +3,12 @@ package com.hubspot.httpql.core.filter;
 /**
  * Marker class for filters. Actual implementation should be added in an *Impl class in another module and reference this class with the getAnnotationClass() method
  */
-public interface FilterIF {
+public interface Filter {
 
+    String[] names();
+
+    default boolean takesMultiParameters() {
+        return false;
+    }
 
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/GreaterThan.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/GreaterThan.java
@@ -1,5 +1,12 @@
 package com.hubspot.httpql.core.filter;
 
-public class GreaterThan  implements FilterIF {
+public class GreaterThan  implements Filter {
+
+    @Override
+    public String[] names() {
+        return new String[] {
+                "gt"
+        };
+    }
 
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/GreaterThanOrEqual.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/GreaterThanOrEqual.java
@@ -1,6 +1,12 @@
 package com.hubspot.httpql.core.filter;
 
-public class GreaterThanOrEqual implements FilterIF {
+public class GreaterThanOrEqual implements Filter {
 
+    @Override
+    public String[] names() {
+        return new String[] {
+                "gte"
+        };
+    }
 
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/In.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/In.java
@@ -1,6 +1,17 @@
 package com.hubspot.httpql.core.filter;
 
-public class In implements FilterIF {
+public class In implements Filter {
 
+    @Override
+    public String[] names() {
+        return new String[] {
+                "in"
+        };
+    }
+
+    @Override
+    public boolean takesMultiParameters() {
+        return true;
+    }
 
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/InsensitiveContains.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/InsensitiveContains.java
@@ -1,5 +1,12 @@
 package com.hubspot.httpql.core.filter;
 
-public class InsensitiveContains implements FilterIF {
+public class InsensitiveContains implements Filter {
+
+    @Override
+    public String[] names() {
+        return new String[] {
+                "icontains", "ilike"
+        };
+    }
 
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/IsDistinctFrom.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/IsDistinctFrom.java
@@ -1,4 +1,17 @@
 package com.hubspot.httpql.core.filter;
 
-public class IsDistinctFrom implements FilterIF {
+public class IsDistinctFrom implements Filter {
+
+    @Override
+    public String[] names() {
+        return new String[] {
+                "distinct"
+        };
+    }
+
+    @Override
+    public boolean takesMultiParameters() {
+        return true;
+    }
+
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/IsNotDistinctFrom.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/IsNotDistinctFrom.java
@@ -1,5 +1,12 @@
 package com.hubspot.httpql.core.filter;
 
-public class IsNotDistinctFrom implements FilterIF {
+public class IsNotDistinctFrom implements Filter {
+
+    @Override
+    public String[] names() {
+        return new String[] {
+                "ndistinct"
+        };
+    }
 
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/LessThan.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/LessThan.java
@@ -2,7 +2,6 @@ package com.hubspot.httpql.core.filter;
 
 public class LessThan implements Filter {
 
-
     @Override
     public String[] names() {
         return new String[] {

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/LessThan.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/LessThan.java
@@ -1,6 +1,13 @@
 package com.hubspot.httpql.core.filter;
 
-public class LessThan implements FilterIF {
+public class LessThan implements Filter {
 
+
+    @Override
+    public String[] names() {
+        return new String[] {
+                "lt"
+        };
+    }
 
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/LessThanOrEqual.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/LessThanOrEqual.java
@@ -1,6 +1,12 @@
 package com.hubspot.httpql.core.filter;
 
-public class LessThanOrEqual implements FilterIF {
+public class LessThanOrEqual implements Filter {
 
+    @Override
+    public String[] names() {
+        return new String[] {
+                "lte"
+        };
+    }
 
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/NotEqual.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/NotEqual.java
@@ -1,6 +1,12 @@
 package com.hubspot.httpql.core.filter;
 
-public class NotEqual implements FilterIF {
+public class NotEqual implements Filter {
 
+    @Override
+    public String[] names() {
+        return new String[] {
+                "ne", "neq", "not"
+        };
+    }
 
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/NotIn.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/NotIn.java
@@ -1,5 +1,17 @@
 package com.hubspot.httpql.core.filter;
 
-public class NotIn implements FilterIF {
+public class NotIn implements Filter {
+
+    @Override
+    public String[] names() {
+        return new String[] {
+                "nin"
+        };
+    }
+
+    @Override
+    public boolean takesMultiParameters() {
+        return true;
+    }
 
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/NotLike.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/NotLike.java
@@ -1,4 +1,18 @@
 package com.hubspot.httpql.core.filter;
 
-public class NotLike implements FilterIF {
+public class NotLike implements Filter {
+
+
+    @Override
+    public String[] names() {
+        return new String[] {
+                "nlike", "not_like"
+        };
+    }
+
+    @Override
+    public boolean takesMultiParameters() {
+        return true;
+    }
+
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/NotLike.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/NotLike.java
@@ -2,7 +2,6 @@ package com.hubspot.httpql.core.filter;
 
 public class NotLike implements Filter {
 
-
     @Override
     public String[] names() {
         return new String[] {

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/NotNull.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/NotNull.java
@@ -1,4 +1,12 @@
 package com.hubspot.httpql.core.filter;
 
-public class NotNull implements FilterIF {
+public class NotNull implements Filter {
+
+    @Override
+    public String[] names() {
+        return new String[] {
+                "not_null"
+        };
+    }
+
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/Null.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/Null.java
@@ -1,4 +1,12 @@
 package com.hubspot.httpql.core.filter;
 
-public class Null implements FilterIF {
+public class Null implements Filter {
+
+    @Override
+    public String[] names() {
+        return new String[] {
+                "is_null"
+        };
+    }
+
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/Range.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/Range.java
@@ -1,6 +1,16 @@
 package com.hubspot.httpql.core.filter;
 
-public class Range implements FilterIF {
+public class Range implements Filter {
 
+    @Override
+    public String[] names() {
+        return new String[] {
+                "range"
+        };
+    }
 
+    @Override
+    public boolean takesMultiParameters() {
+        return true;
+    }
 }

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/filter/StartsWith.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/filter/StartsWith.java
@@ -1,6 +1,13 @@
 package com.hubspot.httpql.core.filter;
 
-public class StartsWith implements FilterIF {
+public class StartsWith implements Filter {
+
+    @Override
+    public String[] names() {
+        return new String[] {
+                "startswith"
+        };
+    }
 
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/Filter.java
+++ b/httpql/src/main/java/com/hubspot/httpql/Filter.java
@@ -1,6 +1,5 @@
 package com.hubspot.httpql;
 
-import com.hubspot.httpql.core.filter.FilterIF;
 import org.jooq.Field;
 
 /**
@@ -8,11 +7,10 @@ import org.jooq.Field;
  *
  * @author tdavis
  */
-public interface Filter extends FilterIF {
+public interface Filter extends com.hubspot.httpql.core.filter.Filter {
   /**
    * List of names the operator goes by in queries; the {@code gt} in {@code foo_gt=1}
    */
-  String[] names();
 
   <T> ConditionProvider<T> getConditionProvider(Field<T> field);
 

--- a/httpql/src/main/java/com/hubspot/httpql/Filters.java
+++ b/httpql/src/main/java/com/hubspot/httpql/Filters.java
@@ -1,8 +1,9 @@
 package com.hubspot.httpql;
 
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.impl.filter.FilterImpl;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -10,24 +11,31 @@ import java.util.ServiceLoader;
 
 public class Filters {
 
-    private static final Map<String, Filter> FILTERS_BY_NAME = new HashMap<>();
+    private static final Map<String, com.hubspot.httpql.Filter> FILTERS_BY_NAME = new HashMap<>();
     private static final Map<String, FilterImpl> FILTER_IMPLS_BY_NAME = new HashMap<>();
-    private static final ServiceLoader<Filter> FILTER_LOADER = ServiceLoader.load(Filter.class);
+    private static final ServiceLoader<com.hubspot.httpql.Filter> FILTER_LOADER = ServiceLoader.load(com.hubspot.httpql.Filter.class);
     private static final ServiceLoader<FilterImpl> FILTER_IMPL_LOADER = ServiceLoader.load(FilterImpl.class);
-    private static final Map<Class<? extends FilterIF>, FilterImpl> FILTER_IMPLS = new HashMap<>();
+    private static final Map<Class<? extends Filter>, FilterImpl> FILTER_IMPLS = new HashMap<>();
 
     static {
-        for (Filter filter : FILTER_LOADER) {
+        for (com.hubspot.httpql.Filter filter : FILTER_LOADER) {
             for (String name : filter.names()) {
                 FILTERS_BY_NAME.put(name, filter);
             }
         }
 
         for (FilterImpl filterImpl : FILTER_IMPL_LOADER) {
-            for (String name : filterImpl.names()) {
-                FILTER_IMPLS_BY_NAME.put(name, filterImpl);
+            for (Class<? extends Filter> annotationClass : filterImpl.getAnnotationClasses()) {
+                try {
+                    Filter filterIF = annotationClass.getDeclaredConstructor().newInstance();
+                    for (String name : filterIF.names()) {
+                        FILTER_IMPLS_BY_NAME.put(name, filterImpl);
+                    }
+                } catch (InstantiationException| IllegalAccessException  | InvocationTargetException | NoSuchMethodException e) {
+                    throw new RuntimeException(e);
+                }
+                filterImpl.getAnnotationClasses().forEach(f -> FILTER_IMPLS.put(f, filterImpl));
             }
-            filterImpl.getAnnotationClasses().forEach(f -> FILTER_IMPLS.put(f, filterImpl));
         }
     }
 
@@ -35,12 +43,12 @@ public class Filters {
         return Optional.ofNullable(FILTER_IMPLS_BY_NAME.get(name));
     }
 
-    public static Optional<FilterImpl> getFilterImpl(Class<? extends FilterIF> filter) {
+    public static Optional<FilterImpl> getFilterImpl(Class<? extends Filter> filter) {
         return Optional.ofNullable(FILTER_IMPLS.get(filter));
     }
 
     @Deprecated
-    public static Optional<Filter> getFilterByName(String name) {
+    public static Optional<com.hubspot.httpql.Filter> getFilterByName(String name) {
         return Optional.ofNullable(FILTERS_BY_NAME.get(name));
     }
 }

--- a/httpql/src/main/java/com/hubspot/httpql/filter/In.java
+++ b/httpql/src/main/java/com/hubspot/httpql/filter/In.java
@@ -1,13 +1,12 @@
 package com.hubspot.httpql.filter;
 
-import java.util.Collection;
-
-import org.jooq.Condition;
-import org.jooq.Field;
-
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.Filter;
 import com.hubspot.httpql.MultiParamConditionProvider;
+import org.jooq.Condition;
+import org.jooq.Field;
+
+import java.util.Collection;
 
 public class In extends FilterBase implements Filter {
 
@@ -16,6 +15,11 @@ public class In extends FilterBase implements Filter {
     return new String[] {
         "in"
     };
+  }
+
+  @Override
+  public boolean takesMultiParameters() {
+    return true;
   }
 
   @Override

--- a/httpql/src/main/java/com/hubspot/httpql/filter/IsDistinctFrom.java
+++ b/httpql/src/main/java/com/hubspot/httpql/filter/IsDistinctFrom.java
@@ -1,15 +1,14 @@
 package com.hubspot.httpql.filter;
 
-import java.util.Collection;
-import java.util.stream.Collectors;
-
+import com.hubspot.httpql.ConditionProvider;
+import com.hubspot.httpql.Filter;
+import com.hubspot.httpql.MultiParamConditionProvider;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.impl.DSL;
 
-import com.hubspot.httpql.ConditionProvider;
-import com.hubspot.httpql.Filter;
-import com.hubspot.httpql.MultiParamConditionProvider;
+import java.util.Collection;
+import java.util.stream.Collectors;
 
 public class IsDistinctFrom extends FilterBase implements Filter {
 
@@ -18,6 +17,11 @@ public class IsDistinctFrom extends FilterBase implements Filter {
     return new String[] {
         "distinct"
     };
+  }
+
+  @Override
+  public boolean takesMultiParameters() {
+    return true;
   }
 
   @Override

--- a/httpql/src/main/java/com/hubspot/httpql/filter/NotIn.java
+++ b/httpql/src/main/java/com/hubspot/httpql/filter/NotIn.java
@@ -1,13 +1,12 @@
 package com.hubspot.httpql.filter;
 
-import java.util.Collection;
-
-import org.jooq.Condition;
-import org.jooq.Field;
-
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.Filter;
 import com.hubspot.httpql.MultiParamConditionProvider;
+import org.jooq.Condition;
+import org.jooq.Field;
+
+import java.util.Collection;
 
 public class NotIn extends FilterBase implements Filter {
 
@@ -17,6 +16,12 @@ public class NotIn extends FilterBase implements Filter {
         "nin"
     };
   }
+
+  @Override
+  public boolean takesMultiParameters() {
+    return true;
+  }
+
 
   @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {

--- a/httpql/src/main/java/com/hubspot/httpql/filter/NotLike.java
+++ b/httpql/src/main/java/com/hubspot/httpql/filter/NotLike.java
@@ -1,14 +1,13 @@
 package com.hubspot.httpql.filter;
 
-import java.util.Collection;
-import java.util.Iterator;
-
-import org.jooq.Condition;
-import org.jooq.Field;
-
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.Filter;
 import com.hubspot.httpql.MultiParamConditionProvider;
+import org.jooq.Condition;
+import org.jooq.Field;
+
+import java.util.Collection;
+import java.util.Iterator;
 
 public class NotLike extends FilterBase implements Filter {
 
@@ -17,6 +16,11 @@ public class NotLike extends FilterBase implements Filter {
     return new String[] {
         "nlike", "not_like"
     };
+  }
+
+  @Override
+  public boolean takesMultiParameters() {
+    return true;
   }
 
   @Override

--- a/httpql/src/main/java/com/hubspot/httpql/filter/Range.java
+++ b/httpql/src/main/java/com/hubspot/httpql/filter/Range.java
@@ -1,19 +1,18 @@
 package com.hubspot.httpql.filter;
 
+import com.google.common.base.Preconditions;
+import com.hubspot.httpql.ConditionProvider;
+import com.hubspot.httpql.Filter;
+import com.hubspot.httpql.MultiParamConditionProvider;
+import org.jooq.Condition;
+import org.jooq.Field;
+
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-
-import org.jooq.Condition;
-import org.jooq.Field;
-
-import com.google.common.base.Preconditions;
-import com.hubspot.httpql.ConditionProvider;
-import com.hubspot.httpql.Filter;
-import com.hubspot.httpql.MultiParamConditionProvider;
 
 public class Range extends FilterBase implements Filter {
 
@@ -30,6 +29,12 @@ public class Range extends FilterBase implements Filter {
         "range"
     };
   }
+
+  @Override
+  public boolean takesMultiParameters() {
+    return true;
+  }
+
 
   @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/ContainsImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/ContainsImpl.java
@@ -3,7 +3,7 @@ package com.hubspot.httpql.impl.filter;
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.core.filter.Contains;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Param;
@@ -13,15 +13,8 @@ import java.util.Set;
 public class ContainsImpl extends FilterBase implements FilterImpl {
 
   @Override
-  public String[] names() {
-    return new String[] {
-        "contains", "like"
-    };
-  }
-
-  @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
-    return new ConditionProvider<T>(field) {
+    return new ConditionProvider<>(field) {
 
       @Override
       public Condition getCondition(Param<T> value) {
@@ -32,7 +25,7 @@ public class ContainsImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(Contains.class, com.hubspot.httpql.filter.Contains.class);
   }
 

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/EqualImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/EqualImpl.java
@@ -3,7 +3,7 @@ package com.hubspot.httpql.impl.filter;
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.core.filter.Equal;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import org.jooq.Condition;
 import org.jooq.Field;
 import org.jooq.Param;
@@ -13,15 +13,8 @@ import java.util.Set;
 public class EqualImpl extends FilterBase implements FilterImpl {
 
   @Override
-  public String[] names() {
-    return new String[] {
-        "eq", "exact", "is"
-    };
-  }
-
-  @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
-    return new ConditionProvider<T>(field) {
+    return new ConditionProvider<>(field) {
 
       @Override
       public Condition getCondition(Param<T> value) {
@@ -32,7 +25,7 @@ public class EqualImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(Equal.class, com.hubspot.httpql.filter.Equal.class);
   }
 

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/FilterImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/FilterImpl.java
@@ -1,7 +1,7 @@
 package com.hubspot.httpql.impl.filter;
 
 import com.hubspot.httpql.ConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import org.jooq.Field;
 
 import java.util.Set;
@@ -15,10 +15,8 @@ public interface FilterImpl {
   /**
    * List of names the operator goes by in queries; the {@code gt} in {@code foo_gt=1}
    */
-  String[] names();
-
   <T> ConditionProvider<T> getConditionProvider(Field<T> field);
 
-  Set<Class<? extends FilterIF>> getAnnotationClasses();
+  Set<Class<? extends Filter>> getAnnotationClasses();
 
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/GreaterThanImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/GreaterThanImpl.java
@@ -2,7 +2,7 @@ package com.hubspot.httpql.impl.filter;
 
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.GreaterThan;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -13,15 +13,8 @@ import java.util.Set;
 public class GreaterThanImpl extends FilterBase implements FilterImpl {
 
   @Override
-  public String[] names() {
-    return new String[] {
-        "gt"
-    };
-  }
-
-  @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
-    return new ConditionProvider<T>(field) {
+    return new ConditionProvider<>(field) {
 
       @Override
       public Condition getCondition(Param<T> value) {
@@ -32,7 +25,7 @@ public class GreaterThanImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(GreaterThan.class, com.hubspot.httpql.filter.GreaterThan.class);
   }
 

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/GreaterThanOrEqualImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/GreaterThanOrEqualImpl.java
@@ -2,7 +2,7 @@ package com.hubspot.httpql.impl.filter;
 
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.GreaterThanOrEqual;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -12,16 +12,10 @@ import java.util.Set;
 
 public class GreaterThanOrEqualImpl extends FilterBase implements FilterImpl {
 
-  @Override
-  public String[] names() {
-    return new String[] {
-        "gte"
-    };
-  }
 
   @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
-    return new ConditionProvider<T>(field) {
+    return new ConditionProvider<>(field) {
 
       @Override
       public Condition getCondition(Param<T> value) {
@@ -31,7 +25,7 @@ public class GreaterThanOrEqualImpl extends FilterBase implements FilterImpl {
     };
   }
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(GreaterThanOrEqual.class, com.hubspot.httpql.filter.GreaterThanOrEqual.class);
   }
 

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/InImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/InImpl.java
@@ -3,7 +3,7 @@ package com.hubspot.httpql.impl.filter;
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.MultiParamConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.In;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -14,15 +14,8 @@ import java.util.Set;
 public class InImpl extends FilterBase implements FilterImpl {
 
   @Override
-  public String[] names() {
-    return new String[] {
-        "in"
-    };
-  }
-
-  @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
-    return new MultiParamConditionProvider<T>(field) {
+    return new MultiParamConditionProvider<>(field) {
 
       @Override
       public Condition getCondition(Collection<T> values) {
@@ -33,7 +26,7 @@ public class InImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(In.class, com.hubspot.httpql.filter.In.class);
   }
 

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/InsensitiveContainsImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/InsensitiveContainsImpl.java
@@ -4,7 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.escape.Escaper;
 import com.google.common.escape.Escapers;
 import com.hubspot.httpql.ConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.InsensitiveContains;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -21,13 +21,6 @@ public class InsensitiveContainsImpl extends FilterBase implements FilterImpl {
       .build();
 
   @Override
-  public String[] names() {
-    return new String[] {
-        "icontains", "ilike"
-    };
-  }
-
-  @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
     return new ConditionProvider<T>(field) {
 
@@ -42,7 +35,7 @@ public class InsensitiveContainsImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(InsensitiveContains.class, com.hubspot.httpql.filter.InsensitiveContains.class);
   }
 

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/IsDistinctFromImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/IsDistinctFromImpl.java
@@ -3,7 +3,7 @@ package com.hubspot.httpql.impl.filter;
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.MultiParamConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.IsDistinctFrom;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -16,15 +16,8 @@ import java.util.stream.Collectors;
 public class IsDistinctFromImpl extends FilterBase implements FilterImpl {
 
   @Override
-  public String[] names() {
-    return new String[] {
-        "distinct"
-    };
-  }
-
-  @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
-    return new MultiParamConditionProvider<T>(field) {
+    return new MultiParamConditionProvider<>(field) {
 
       @Override
       public Condition getCondition(Collection<T> values) {
@@ -36,7 +29,7 @@ public class IsDistinctFromImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(IsDistinctFrom.class, com.hubspot.httpql.filter.IsDistinctFrom.class);
   }
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/IsNotDistinctFromImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/IsNotDistinctFromImpl.java
@@ -2,7 +2,7 @@ package com.hubspot.httpql.impl.filter;
 
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.IsNotDistinctFrom;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -13,15 +13,8 @@ import java.util.Set;
 public class IsNotDistinctFromImpl extends FilterBase implements FilterImpl {
 
   @Override
-  public String[] names() {
-    return new String[] {
-        "ndistinct"
-    };
-  }
-
-  @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
-    return new ConditionProvider<T>(field) {
+    return new ConditionProvider<>(field) {
 
       @Override
       public Condition getCondition(Param<T> value) {
@@ -31,7 +24,7 @@ public class IsNotDistinctFromImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(IsNotDistinctFrom.class, com.hubspot.httpql.filter.IsNotDistinctFrom.class);
   }
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/LessThanImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/LessThanImpl.java
@@ -2,7 +2,7 @@ package com.hubspot.httpql.impl.filter;
 
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.LessThan;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -13,15 +13,8 @@ import java.util.Set;
 public class LessThanImpl extends FilterBase implements FilterImpl {
 
   @Override
-  public String[] names() {
-    return new String[] {
-        "lt"
-    };
-  }
-
-  @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
-    return new ConditionProvider<T>(field) {
+    return new ConditionProvider<>(field) {
 
       @Override
       public Condition getCondition(Param<T> value) {
@@ -32,7 +25,7 @@ public class LessThanImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(LessThan.class, com.hubspot.httpql.filter.LessThan.class);
   }
 

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/LessThanOrEqualImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/LessThanOrEqualImpl.java
@@ -2,7 +2,7 @@ package com.hubspot.httpql.impl.filter;
 
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.LessThanOrEqual;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -13,15 +13,8 @@ import java.util.Set;
 public class LessThanOrEqualImpl extends FilterBase implements FilterImpl {
 
   @Override
-  public String[] names() {
-    return new String[] {
-        "lte"
-    };
-  }
-
-  @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
-    return new ConditionProvider<T>(field) {
+    return new ConditionProvider<>(field) {
 
       @Override
       public Condition getCondition(Param<T> value) {
@@ -32,7 +25,7 @@ public class LessThanOrEqualImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(LessThanOrEqual.class, com.hubspot.httpql.filter.LessThanOrEqual.class);
   }
 

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotEqualImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotEqualImpl.java
@@ -2,7 +2,7 @@ package com.hubspot.httpql.impl.filter;
 
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.NotEqual;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -13,15 +13,8 @@ import java.util.Set;
 public class NotEqualImpl extends FilterBase implements FilterImpl {
 
   @Override
-  public String[] names() {
-    return new String[] {
-        "ne", "neq", "not"
-    };
-  }
-
-  @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
-    return new ConditionProvider<T>(field) {
+    return new ConditionProvider<>(field) {
 
       @Override
       public Condition getCondition(Param<T> value) {
@@ -32,7 +25,7 @@ public class NotEqualImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(NotEqual.class, com.hubspot.httpql.filter.NotEqual.class);
   }
 

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotInImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotInImpl.java
@@ -3,7 +3,7 @@ package com.hubspot.httpql.impl.filter;
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.MultiParamConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.NotIn;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -14,15 +14,8 @@ import java.util.Set;
 public class NotInImpl extends FilterBase implements FilterImpl {
 
   @Override
-  public String[] names() {
-    return new String[] {
-        "nin"
-    };
-  }
-
-  @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
-    return new MultiParamConditionProvider<T>(field) {
+    return new MultiParamConditionProvider<>(field) {
 
       @Override
       public Condition getCondition(Collection<T> values) {
@@ -33,7 +26,7 @@ public class NotInImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(NotIn.class, com.hubspot.httpql.filter.NotIn.class);
   }
 

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotLikeImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotLikeImpl.java
@@ -3,7 +3,7 @@ package com.hubspot.httpql.impl.filter;
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.MultiParamConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.NotLike;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -13,17 +13,9 @@ import java.util.Iterator;
 import java.util.Set;
 
 public class NotLikeImpl extends FilterBase implements FilterImpl {
-
-  @Override
-  public String[] names() {
-    return new String[] {
-        "nlike", "not_like"
-    };
-  }
-
   @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
-    return new MultiParamConditionProvider<T>(field) {
+    return new MultiParamConditionProvider<>(field) {
 
       @Override
       public Condition getCondition(Collection<T> values) {
@@ -39,7 +31,7 @@ public class NotLikeImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(NotLike.class, com.hubspot.httpql.filter.NotLike.class);
   }
 

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotNullImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/NotNullImpl.java
@@ -2,7 +2,7 @@ package com.hubspot.httpql.impl.filter;
 
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.NotNull;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -12,15 +12,8 @@ import java.util.Set;
 
 public class NotNullImpl extends FilterBase implements FilterImpl {
   @Override
-  public String[] names() {
-    return new String[] {
-        "not_null"
-    };
-  }
-
-  @Override
   public <T> ConditionProvider<T> getConditionProvider(Field<T> field) {
-    return new ConditionProvider<T>(field) {
+    return new ConditionProvider<>(field) {
 
       @Override
       public Condition getCondition(Param<T> value) {
@@ -30,7 +23,7 @@ public class NotNullImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(NotNull.class, com.hubspot.httpql.filter.NotNull.class);
   }
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/NullImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/NullImpl.java
@@ -2,7 +2,7 @@ package com.hubspot.httpql.impl.filter;
 
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.Null;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -11,13 +11,6 @@ import org.jooq.Param;
 import java.util.Set;
 
 public class NullImpl extends FilterBase implements FilterImpl {
-  @Override
-  public String[] names() {
-    return new String[] {
-        "is_null"
-    };
-  }
-
   @Override
   public <T> ConditionProvider<T> getConditionProvider(Field<T> field) {
     return new ConditionProvider<T>(field) {
@@ -30,7 +23,7 @@ public class NullImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(Null.class, com.hubspot.httpql.filter.Null.class);
   }
 }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/RangeImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/RangeImpl.java
@@ -4,7 +4,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
 import com.hubspot.httpql.MultiParamConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.Range;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -12,26 +12,13 @@ import org.jooq.Field;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
 public class RangeImpl extends FilterBase implements FilterImpl {
 
-  private static final Comparator<Number> NUMBER_COMPARATOR = new Comparator<Number>() {
-    @Override
-    public int compare(Number a, Number b) {
-      return new BigDecimal(a.toString()).compareTo(new BigDecimal(b.toString()));
-    }
-  };
-
-  @Override
-  public String[] names() {
-    return new String[] {
-        "range"
-    };
-  }
+  private static final Comparator<Number> NUMBER_COMPARATOR = Comparator.comparing(a -> new BigDecimal(a.toString()));
 
   @Override
   public <T> ConditionProvider<T> getConditionProvider(final Field<T> field) {
@@ -40,17 +27,17 @@ public class RangeImpl extends FilterBase implements FilterImpl {
       @SuppressWarnings("unchecked")
       @Override
       public Condition getCondition(Collection<T> values) {
-        List<Number> valueList = new ArrayList<Number>((Collection<? extends Number>) values);
+        List<Number> valueList = new ArrayList<>((Collection<? extends Number>) values);
         Preconditions.checkArgument(valueList.size() == 2, "Range filters require exactly 2 parameters");
 
-        Collections.sort(valueList, NUMBER_COMPARATOR);
+        valueList.sort(NUMBER_COMPARATOR);
         return field.between((T) valueList.get(0), (T) valueList.get(1));
       }
 
     };
   }
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(Range.class, com.hubspot.httpql.filter.Range.class);
   }
 

--- a/httpql/src/main/java/com/hubspot/httpql/impl/filter/StartsWithImpl.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/filter/StartsWithImpl.java
@@ -2,7 +2,7 @@ package com.hubspot.httpql.impl.filter;
 
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.httpql.ConditionProvider;
-import com.hubspot.httpql.core.filter.FilterIF;
+import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.core.filter.StartsWith;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -11,13 +11,6 @@ import org.jooq.Param;
 import java.util.Set;
 
 public class StartsWithImpl extends FilterBase implements FilterImpl {
-
-  @Override
-  public String[] names() {
-    return new String[] {
-        "startswith"
-    };
-  }
 
   @Override
   public <T> ConditionProvider<T> getConditionProvider(Field<T> field) {
@@ -32,7 +25,7 @@ public class StartsWithImpl extends FilterBase implements FilterImpl {
   }
 
   @Override
-  public Set<Class<? extends FilterIF>> getAnnotationClasses() {
+  public Set<Class<? extends Filter>> getAnnotationClasses() {
     return ImmutableSet.of(StartsWith.class, com.hubspot.httpql.filter.StartsWith.class);
   }
 


### PR DESCRIPTION
I thought I could completely remove all methods from `Filter`s and put them all in `FilterImpl`s, but it turns out there's a few cases where we need the `names()` method in code that doesn't need `FilterImpl`s. There was also some weird logic for trying to figure out if Filter allowed multiple parameters, so I added a simple boolean for that.

I'm flip flopping on renaming the new Filter interface to FilterIF because keeping the same name will mean fewer diffs for migrations.