### PR TITLE
add OrderingIF

### DIFF
--- a/httpql-core/pom.xml
+++ b/httpql-core/pom.xml
@@ -28,6 +28,10 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>junit</groupId>

--- a/httpql-core/pom.xml
+++ b/httpql-core/pom.xml
@@ -29,6 +29,18 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/Ordering.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/Ordering.java
@@ -1,18 +1,11 @@
-package com.hubspot.httpql.impl;
+package com.hubspot.httpql.core;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Splitter;
-import com.hubspot.httpql.core.OrderingIF;
-import org.jooq.SortOrder;
 
 import java.util.List;
 import java.util.Objects;
 
-/**
- * @deprecated Use {@link com.hubspot.httpql.core.Ordering}
- */
-@Deprecated
 public class Ordering implements OrderingIF {
   private static final Splitter FIELD_SPLITTER = Splitter.on(',');
 
@@ -34,7 +27,6 @@ public class Ordering implements OrderingIF {
     this.queryName = queryName;
   }
 
-  @JsonCreator
   public static Ordering fromString(String ordering) {
     SortOrder order;
     if (ordering.startsWith("-")) {
@@ -63,22 +55,24 @@ public class Ordering implements OrderingIF {
     return json.toString();
   }
 
+  @Override
   public String getQueryName() {
     return queryName;
   }
 
+  @Override
   public String getFieldName() {
     return fieldName;
   }
 
   @Override
   public int getSortOrdinal() {
-    return getOrder().ordinal();
+    return order.ordinal();
   }
 
   @Override
   public String getOrderString() {
-    return getOrder().toSQL();
+    return getOrder().toString();
   }
 
   public SortOrder getOrder() {

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/OrderingIF.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/OrderingIF.java
@@ -1,0 +1,12 @@
+package com.hubspot.httpql.core;
+
+public interface OrderingIF {
+
+    String getQueryName();
+
+    String getFieldName();
+
+    int getSortOrdinal();
+
+    String getOrderString();
+}

--- a/httpql-core/src/main/java/com/hubspot/httpql/core/SortOrder.java
+++ b/httpql-core/src/main/java/com/hubspot/httpql/core/SortOrder.java
@@ -1,0 +1,29 @@
+package com.hubspot.httpql.core;
+
+public enum SortOrder {
+
+    /**
+     * Ascending sort order.
+     */
+    ASC("asc"),
+
+    /**
+     * Descending sort order.
+     */
+    DESC("desc"),
+
+    /**
+     * Default sort order.
+     */
+    DEFAULT("");
+
+    private final String sql;
+
+    SortOrder(String sql) {
+        this.sql = sql;
+    }
+
+    public final String toSQL() {
+        return sql;
+    }
+}

--- a/httpql-core/src/test/java/com/hubspot/httpql/core/OrderingTest.java
+++ b/httpql-core/src/test/java/com/hubspot/httpql/core/OrderingTest.java
@@ -1,0 +1,50 @@
+package com.hubspot.httpql.core;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class OrderingTest {
+
+  private ObjectMapper mapper;
+
+  @Before
+  public void setup() {
+    mapper = new ObjectMapper();
+  }
+
+  @Test
+  public void testJsonWithField() throws Exception {
+    Ordering o1 = new Ordering("foo", SortOrder.ASC);
+    String json = mapper.writeValueAsString(o1);
+
+    Ordering o2 = mapper.readValue(json, Ordering.class);
+    assertThat(o2).isEqualToComparingFieldByField(o1);
+    assertThat(o2.equals(o1)).isTrue();
+
+    o1 = new Ordering("foo", SortOrder.DESC);
+    json = mapper.writeValueAsString(o1);
+
+    o2 = mapper.readValue(json, Ordering.class);
+    assertThat(o2).isEqualToComparingFieldByField(o1);
+  }
+
+  @Test
+  public void testJsonWithQueryField() throws Exception {
+    Ordering o1 = new Ordering("foo", "bar", SortOrder.ASC);
+    String json = mapper.writeValueAsString(o1);
+
+    Ordering o2 = mapper.readValue(json, Ordering.class);
+    assertThat(o2).isEqualToComparingFieldByField(o1);
+    assertThat(o2.equals(o1)).isTrue();
+
+    o1 = new Ordering("foo", "bar", SortOrder.DESC);
+    json = mapper.writeValueAsString(o1);
+
+    o2 = mapper.readValue(json, Ordering.class);
+    assertThat(o2).isEqualToComparingFieldByField(o1);
+  }
+
+}

--- a/httpql/src/main/java/com/hubspot/httpql/impl/QueryParser.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/QueryParser.java
@@ -20,6 +20,7 @@ import com.hubspot.httpql.QueryConstraints;
 import com.hubspot.httpql.QuerySpec;
 import com.hubspot.httpql.ann.FilterBy;
 import com.hubspot.httpql.ann.OrderBy;
+import com.hubspot.httpql.core.OrderingIF;
 import com.hubspot.httpql.error.ConstraintType;
 import com.hubspot.httpql.error.ConstraintViolation;
 import com.hubspot.httpql.error.FilterViolation;
@@ -124,7 +125,7 @@ public class QueryParser<T extends QuerySpec> {
     final Optional<Integer> limit = getLimit(parsedUriParams.getLimit());
     final Optional<Integer> offset = getOffset(parsedUriParams.getOffset());
 
-    final Collection<Ordering> orderings = getOrderings(parsedUriParams.getOrderBys(), meta);
+    final Collection<OrderingIF> orderings = getOrderings(parsedUriParams.getOrderBys(), meta);
 
     final Table<BoundFilterEntry<T>, String, BeanPropertyDefinition> filterTable = meta.getFilterTable();
     final Map<String, BeanPropertyDefinition> fieldMap = meta.getFieldMap();
@@ -264,18 +265,18 @@ public class QueryParser<T extends QuerySpec> {
     return Optional.empty();
   }
 
-  protected Collection<Ordering> getOrderings(List<String> orderStrings, MetaQuerySpec<T> meta) {
-    Collection<Ordering> orderings = new ArrayList<>();
+  protected Collection<OrderingIF> getOrderings(List<String> orderStrings, MetaQuerySpec<T> meta) {
+    Collection<OrderingIF> orderings = new ArrayList<>();
     if (orderStrings != null) {
       for (String order : orderStrings) {
-        Ordering ordering = Ordering.fromString(order);
+        com.hubspot.httpql.core.Ordering ordering = com.hubspot.httpql.core.Ordering.fromString(order);
         FilterEntry entry = new FilterEntry(null, ordering.getFieldName(), getQueryType());
         BeanPropertyDefinition prop = meta.getFieldMap().get(entry.getQueryName());
         if (prop == null) {
           prop = meta.getFieldMap().get(entry.getFieldName());
         }
         if (prop != null && orderableFields.contains(prop.getName())) {
-          orderings.add(new Ordering(entry.getFieldName(), entry.getQueryName(), ordering.getOrder()));
+          orderings.add(new com.hubspot.httpql.core.Ordering(entry.getFieldName(), entry.getQueryName(), ordering.getOrder()));
         }
       }
     }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/SelectBuilder.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/SelectBuilder.java
@@ -1,11 +1,14 @@
 package com.hubspot.httpql.impl;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-
+import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import com.hubspot.httpql.FieldFactory;
+import com.hubspot.httpql.MetaQuerySpec;
+import com.hubspot.httpql.ParsedQuery;
+import com.hubspot.httpql.QuerySpec;
+import com.hubspot.httpql.ann.OrderBy;
+import com.hubspot.httpql.core.OrderingIF;
+import com.hubspot.httpql.internal.BoundFilterEntry;
+import com.hubspot.httpql.internal.JoinFilter;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Field;
@@ -19,6 +22,7 @@ import org.jooq.SelectOffsetStep;
 import org.jooq.SelectOrderByStep;
 import org.jooq.SelectSelectStep;
 import org.jooq.SortField;
+import org.jooq.SortOrder;
 import org.jooq.Table;
 import org.jooq.TableLike;
 import org.jooq.conf.ParamType;
@@ -26,14 +30,11 @@ import org.jooq.conf.RenderNameStyle;
 import org.jooq.conf.Settings;
 import org.jooq.impl.DSL;
 
-import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
-import com.hubspot.httpql.FieldFactory;
-import com.hubspot.httpql.MetaQuerySpec;
-import com.hubspot.httpql.ParsedQuery;
-import com.hubspot.httpql.QuerySpec;
-import com.hubspot.httpql.ann.OrderBy;
-import com.hubspot.httpql.internal.BoundFilterEntry;
-import com.hubspot.httpql.internal.JoinFilter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Translates the high-level parsed query into a JOOQ Select and/or String representation.
@@ -331,14 +332,14 @@ public class SelectBuilder<T extends QuerySpec> {
 
   public Collection<SortField<?>> orderingsToSortFields() {
     ArrayList<SortField<?>> sorts = new ArrayList<>(sourceQuery.getOrderings().size());
-    for (Ordering order : sourceQuery.getOrderings()) {
-      sorts.add(getSortField(order).sort(order.getOrder()));
+    for (OrderingIF order : sourceQuery.getOrderings()) {
+      sorts.add(getSortField(order).sort(SortOrder.valueOf(order.getOrderString())));
     }
     return sorts;
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})
-  private Field getSortField(Ordering order) {
+  private Field getSortField(OrderingIF order) {
     Map<String, BeanPropertyDefinition> fieldMap = meta.getFieldMap();
     BeanPropertyDefinition bpd = fieldMap.get(order.getQueryName());
     String fieldName = order.getQueryName();

--- a/httpql/src/test/java/com/hubspot/httpql/ParsedQueryTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/ParsedQueryTest.java
@@ -1,14 +1,5 @@
 package com.hubspot.httpql;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.util.Set;
-
-import org.apache.commons.lang.StringUtils;
-import org.jooq.Param;
-import org.junit.Before;
-import org.junit.Test;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
@@ -20,6 +11,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
 import com.hubspot.httpql.ann.FilterBy;
 import com.hubspot.httpql.ann.OrderBy;
+import com.hubspot.httpql.core.OrderingIF;
 import com.hubspot.httpql.filter.Contains;
 import com.hubspot.httpql.filter.Equal;
 import com.hubspot.httpql.filter.GreaterThan;
@@ -29,11 +21,18 @@ import com.hubspot.httpql.filter.IsNotDistinctFrom;
 import com.hubspot.httpql.filter.NotIn;
 import com.hubspot.httpql.filter.NotLike;
 import com.hubspot.httpql.impl.DefaultFieldFactory;
-import com.hubspot.httpql.impl.Ordering;
 import com.hubspot.httpql.impl.QueryParser;
 import com.hubspot.httpql.internal.BoundFilterEntry;
 import com.hubspot.httpql.internal.MultiValuedBoundFilterEntry;
 import com.hubspot.rosetta.annotations.RosettaNaming;
+import org.apache.commons.lang.StringUtils;
+import org.jooq.Param;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ParsedQueryTest {
 
@@ -204,7 +203,7 @@ public class ParsedQueryTest {
     ParsedQuery<Spec> parsed = parser.parse(query);
 
     assertThat(parsed.getOrderings()).hasSize(1);
-    for (Ordering ordering : parsed.getOrderings()) {
+    for (OrderingIF ordering : parsed.getOrderings()) {
       assertThat(ordering.getFieldName()).isEqualTo("count");
     }
   }


### PR DESCRIPTION
This adds an interface for ordering that allows either the Ordering implementation in the current module or the new one in the core module to be used. This should make it easier for migrations as the methods can accept either object.