### PR TITLE
use new queryconstraings

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/impl/QueryParser.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/QueryParser.java
@@ -83,6 +83,15 @@ public class QueryParser<T extends QuerySpec> {
   }
 
   protected void setConstraints(final Class<T> spec) {
+
+    com.hubspot.httpql.core.ann.QueryConstraints qc = spec.getAnnotation(com.hubspot.httpql.core.ann.QueryConstraints.class);
+    if (qc != null) {
+      this.defaultLimit = qc.defaultLimit();
+      this.maxLimit = qc.maxLimit();
+      this.maxOffset = qc.maxOffset();
+      return;
+    }
+
     QueryConstraints ann = spec.getAnnotation(QueryConstraints.class);
     if (ann != null) {
       this.defaultLimit = ann.defaultLimit();

--- a/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserTest.java
@@ -53,7 +53,7 @@ public class QueryParserTest {
     ParsedQuery<Spec> parsedQuery = parser.parse(query);
 
     assertThat(StringUtils.normalizeSpace(SelectBuilder.forParsedQuery(parsedQuery).build().getRawSelect().toString()))
-        .isEqualTo("select * from where `id` in ( 1, 2, 3 ) limit 10");
+        .isEqualTo("select * from where `id` in ( 1, 2, 3 ) limit 20");
   }
 
   @Test
@@ -63,7 +63,7 @@ public class QueryParserTest {
     ParsedQuery<Spec> parsedQuery = parser.parse(query);
 
     assertThat(StringUtils.normalizeSpace(SelectBuilder.forParsedQuery(parsedQuery).build().getRawSelect().toString()))
-        .isEqualTo("select * from where `id` in ( 1, 2, 3 ) limit 10");
+        .isEqualTo("select * from where `id` in ( 1, 2, 3 ) limit 20");
   }
 
   @Test
@@ -135,9 +135,9 @@ public class QueryParserTest {
   @Test
   public void itUsesDefaultsWhenHigherThanMaxValues() {
     Optional<Integer> limit = parser.getLimit(Optional.of(1000));
-    assertThat(limit.get()).isEqualTo(100);
-    Optional<Integer> offset = parser.getOffset(Optional.of(200));
-    assertThat(offset.get()).isEqualTo(100);
+    assertThat(limit.get()).isEqualTo(200);
+    Optional<Integer> offset = parser.getOffset(Optional.of(300));
+    assertThat(offset.get()).isEqualTo(200);
   }
 
   @Test
@@ -154,6 +154,7 @@ public class QueryParserTest {
     assertThat(spec.getId()).isNull();
   }
 
+  @com.hubspot.httpql.core.ann.QueryConstraints(defaultLimit = 20, maxLimit = 200, maxOffset = 200)
   @QueryConstraints(defaultLimit = 10, maxLimit = 100, maxOffset = 100)
   @RosettaNaming(SnakeCaseStrategy.class)
   public static class Spec implements QuerySpec {


### PR DESCRIPTION
This looks for the new and old `QueryConstraints` annotations, so either can be used.