### PR TITLE
implement new join descriptors

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/core/ann/FilterJoin.java
+++ b/httpql/src/main/java/com/hubspot/httpql/core/ann/FilterJoin.java
@@ -5,9 +5,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-/**
- * TODO: implement
- */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({
     ElementType.FIELD, ElementType.METHOD

--- a/httpql/src/main/java/com/hubspot/httpql/core/ann/FilterJoinByDescriptor.java
+++ b/httpql/src/main/java/com/hubspot/httpql/core/ann/FilterJoinByDescriptor.java
@@ -5,11 +5,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-;
-
-/**
- * TODO: implement
- */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({
     ElementType.FIELD, ElementType.METHOD

--- a/httpql/src/main/java/com/hubspot/httpql/impl/DefaultMetaQuerySpec.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/DefaultMetaQuerySpec.java
@@ -8,7 +8,6 @@ import com.hubspot.httpql.FieldFactory;
 import com.hubspot.httpql.Filters;
 import com.hubspot.httpql.MetaQuerySpec;
 import com.hubspot.httpql.QuerySpec;
-import com.hubspot.httpql.ann.FilterJoin;
 import com.hubspot.httpql.ann.desc.JoinDescriptor;
 import com.hubspot.httpql.core.filter.Filter;
 import com.hubspot.httpql.error.FilterViolation;
@@ -99,7 +98,7 @@ public class DefaultMetaQuerySpec<T extends QuerySpec> implements MetaQuerySpec<
 
     JoinCondition join = null;
 
-    FilterJoin filterJoin = DefaultMetaUtils.findFilterJoin(field);
+    FilterJoinInfo filterJoin = DefaultMetaUtils.findFilterJoin(field);
     if (filterJoin != null) {
       join = new JoinCondition(DSL.table(DSL.name(filterJoin.table())),
           DSL.field(DSL.name(instance.tableName(), filterJoin.on()))

--- a/httpql/src/main/java/com/hubspot/httpql/impl/FilterJoinInfo.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/FilterJoinInfo.java
@@ -1,7 +1,5 @@
 package com.hubspot.httpql.impl;
 
-import com.hubspot.httpql.ann.FilterJoin;
-
 import javax.annotation.Nullable;
 
 public class FilterJoinInfo {
@@ -11,11 +9,11 @@ public class FilterJoinInfo {
     private final String eq;
 
     @Nullable
-    public static FilterJoinInfo of(@Nullable  FilterJoin filterJoin) {
+    public static FilterJoinInfo of(@Nullable com.hubspot.httpql.ann.FilterJoin filterJoin) {
         if (filterJoin == null) {
             return null;
         }
-        return new FilterJoinInfo(filterJoin);
+        return new FilterJoinInfo(filterJoin.on(), filterJoin.table(), filterJoin.eq());
     }
 
     @Nullable
@@ -23,21 +21,14 @@ public class FilterJoinInfo {
         if (filterJoin == null) {
             return null;
         }
-        return new FilterJoinInfo(filterJoin);
+        return new FilterJoinInfo(filterJoin.on(), filterJoin.table(), filterJoin.eq());
     }
 
-    private FilterJoinInfo(FilterJoin filterJoin) {
-        this.on = filterJoin.on();
-        this.table = filterJoin.table();
-        this.eq = filterJoin.eq();
+    private FilterJoinInfo(String on, String table, String eq) {
+        this.on = on;
+        this.table = table;
+        this.eq = eq;
     }
-
-    private FilterJoinInfo(com.hubspot.httpql.core.ann.FilterJoin filterJoin) {
-        this.on = filterJoin.on();
-        this.table = filterJoin.table();
-        this.eq = filterJoin.eq();
-    }
-
     public String on() {
         return on;
     }

--- a/httpql/src/main/java/com/hubspot/httpql/impl/FilterJoinInfo.java
+++ b/httpql/src/main/java/com/hubspot/httpql/impl/FilterJoinInfo.java
@@ -1,0 +1,52 @@
+package com.hubspot.httpql.impl;
+
+import com.hubspot.httpql.ann.FilterJoin;
+
+import javax.annotation.Nullable;
+
+public class FilterJoinInfo {
+
+    private final String on;
+    private final String table;
+    private final String eq;
+
+    @Nullable
+    public static FilterJoinInfo of(@Nullable  FilterJoin filterJoin) {
+        if (filterJoin == null) {
+            return null;
+        }
+        return new FilterJoinInfo(filterJoin);
+    }
+
+    @Nullable
+    public static FilterJoinInfo of(@Nullable com.hubspot.httpql.core.ann.FilterJoin filterJoin) {
+        if (filterJoin == null) {
+            return null;
+        }
+        return new FilterJoinInfo(filterJoin);
+    }
+
+    private FilterJoinInfo(FilterJoin filterJoin) {
+        this.on = filterJoin.on();
+        this.table = filterJoin.table();
+        this.eq = filterJoin.eq();
+    }
+
+    private FilterJoinInfo(com.hubspot.httpql.core.ann.FilterJoin filterJoin) {
+        this.on = filterJoin.on();
+        this.table = filterJoin.table();
+        this.eq = filterJoin.eq();
+    }
+
+    public String on() {
+        return on;
+    }
+
+    public String table() {
+        return table;
+    }
+
+    public String eq() {
+        return eq;
+    }
+}

--- a/httpql/src/main/java/com/hubspot/httpql/internal/BoundFilterEntry.java
+++ b/httpql/src/main/java/com/hubspot/httpql/internal/BoundFilterEntry.java
@@ -8,9 +8,9 @@ import com.hubspot.httpql.FieldFactory;
 import com.hubspot.httpql.MetaQuerySpec;
 import com.hubspot.httpql.MultiParamConditionProvider;
 import com.hubspot.httpql.QuerySpec;
-import com.hubspot.httpql.ann.FilterJoin;
 import com.hubspot.httpql.ann.desc.JoinDescriptor;
 import com.hubspot.httpql.impl.DefaultFieldFactory;
+import com.hubspot.httpql.impl.FilterJoinInfo;
 import com.hubspot.httpql.impl.filter.FilterImpl;
 import org.jooq.Condition;
 import org.jooq.Field;
@@ -64,7 +64,7 @@ public class BoundFilterEntry<T extends QuerySpec> extends FilterEntry implement
   public ConditionProvider<?> getConditionProvider(FieldFactory fieldFactory) {
     Field<?> field;
 
-    FilterJoin join = DefaultMetaUtils.findFilterJoin(prop);
+    FilterJoinInfo join = DefaultMetaUtils.findFilterJoin(prop);
     JoinDescriptor joinDescriptor = DefaultMetaUtils.findJoinDescriptor(prop);
     if (join != null) {
       field = DSL.field(DSL.name(join.table(), getQueryName()));

--- a/httpql/src/test/java/com/hubspot/httpql/model/EntityWithSimpleJoin.java
+++ b/httpql/src/test/java/com/hubspot/httpql/model/EntityWithSimpleJoin.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.hubspot.httpql.QueryConstraints;
 import com.hubspot.httpql.QuerySpec;
 import com.hubspot.httpql.ann.FilterBy;
-import com.hubspot.httpql.ann.FilterJoin;
 import com.hubspot.httpql.filter.Equal;
 import com.hubspot.httpql.filter.In;
 import com.hubspot.rosetta.annotations.RosettaNaming;
@@ -17,7 +16,7 @@ public class EntityWithSimpleJoin implements QuerySpec {
   private Long id;
 
   @FilterBy(value = {In.class, Equal.class})
-  @FilterJoin(table = "join_tbl", on = "id", eq = "entity_id")
+  @com.hubspot.httpql.core.ann.FilterJoin(table = "join_tbl", on = "id", eq = "entity_id")
   private Long topicId;
 
   public Long getId() {

--- a/httpql/src/test/java/com/hubspot/httpql/model/EntityWithSimpleJoinDescriptor.java
+++ b/httpql/src/test/java/com/hubspot/httpql/model/EntityWithSimpleJoinDescriptor.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.hubspot.httpql.QueryConstraints;
 import com.hubspot.httpql.QuerySpec;
 import com.hubspot.httpql.ann.FilterBy;
-import com.hubspot.httpql.ann.FilterJoinByDescriptor;
+import com.hubspot.httpql.core.ann.FilterJoinByDescriptor;
 import com.hubspot.httpql.filter.Equal;
 import com.hubspot.httpql.filter.In;
 import com.hubspot.rosetta.annotations.RosettaNaming;
@@ -17,7 +17,7 @@ public class EntityWithSimpleJoinDescriptor implements QuerySpec {
   private Long id;
 
   @FilterBy(value = {In.class, Equal.class})
-  @FilterJoinByDescriptor(EntitySimpleJoinDescriptor.class)
+  @FilterJoinByDescriptor("com.hubspot.httpql.model.EntitySimpleJoinDescriptor")
   private Long topicId;
 
   public Long getId() {


### PR DESCRIPTION
This is the last of the new annotations that need to be implemented. The old FilterJoin annotations are still supported.