### PR TITLE
forward compatibility with jackson having removed LowerCaseWithUnderscoresStrategy

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/DefaultMetaUtils.java
+++ b/httpql/src/main/java/com/hubspot/httpql/DefaultMetaUtils.java
@@ -1,7 +1,6 @@
 package com.hubspot.httpql;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy.SnakeCaseStrategy;
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
@@ -21,6 +20,9 @@ import javax.annotation.Nullable;
 
 @SuppressWarnings("deprecation")
 public class DefaultMetaUtils {
+
+  private static final String LOWER_CASE_WITH_UNDERSCORES_STRATEGY_CLASS_NAME =
+    "com.fasterxml.jackson.databind.PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy";
 
   public static boolean hasOrderBy(BeanPropertyDefinition prop) {
     return (
@@ -127,7 +129,9 @@ public class DefaultMetaUtils {
 
     boolean snakeCasing =
       rosettaNaming != null &&
-      (rosettaNaming.value().equals(LowerCaseWithUnderscoresStrategy.class) ||
+      (LOWER_CASE_WITH_UNDERSCORES_STRATEGY_CLASS_NAME.equals(
+          rosettaNaming.value().getCanonicalName()
+        ) ||
         rosettaNaming.value().equals(SnakeCaseStrategy.class) ||
         rosettaNaming.value().equals(PropertyNamingStrategies.SnakeCaseStrategy.class));
 

--- a/httpql/src/test/java/com/hubspot/httpql/DefaultMetaUtilsTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/DefaultMetaUtilsTest.java
@@ -1,0 +1,41 @@
+package com.hubspot.httpql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.hubspot.rosetta.annotations.RosettaNaming;
+import org.junit.Test;
+
+public class DefaultMetaUtilsTest {
+
+  @Test
+  public void itCorrectlyDetectsAndConvertsToSnakeCase() {
+    assertThat(DefaultMetaUtils.convertToSnakeCaseIfSupported("aCamelCase", test.class))
+      .isEqualTo("a_camel_case");
+    assertThat(DefaultMetaUtils.convertToSnakeCaseIfSupported("ACamelCase", test1.class))
+      .isEqualTo("a_camel_case");
+    /*
+     * LowerCaseWithUnderscoresStrategy has been removed in later version of jackson, commenting out for compatibility
+     * assertThat(DefaultMetaUtils.convertToSnakeCaseIfSupported("ACamelCase", test2.class))
+     * .isEqualTo("a_camel_case");
+     */
+    assertThat(
+      DefaultMetaUtils.convertToSnakeCaseIfSupported(
+        "ACamelCase",
+        DefaultMetaUtilsTest.class
+      )
+    )
+      .isEqualTo("ACamelCase");
+  }
+
+  @RosettaNaming(PropertyNamingStrategy.SnakeCaseStrategy.class)
+  public static class test {}
+
+  @RosettaNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+  public static class test1 {}
+  /*
+   * @RosettaNaming(PropertyNamingStrategy.LowerCaseWithUnderscoresStrategy.class)
+   * public static class test2 {}
+   */
+}


### PR DESCRIPTION
This PR removes compile time dependency on Jackson's `LowerCaseWithUnderscoresStrategy` while maintaining backwards compatibility. Jackson removed `LowerCaseWithUnderscoresStrategy` which was already marked for deprecation in later versions of Jackson.