### PR TITLE
Remove setConverted method usage

### DIFF
--- a/httpql/src/main/java/com/hubspot/httpql/ConditionProvider.java
+++ b/httpql/src/main/java/com/hubspot/httpql/ConditionProvider.java
@@ -25,9 +25,7 @@ public abstract class ConditionProvider<T> {
   }
 
   public Param<T> getParam(Object value, String paramName) {
-    Param<T> param = DSL.param(paramName, field.getType());
-    param.setConverted(value);
-    return param;
+    return DSL.param(paramName, field.getDataType().convert(value));
   }
 
   public Condition getCondition(Object value, String paramName) {

--- a/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserComplexJoinDescriptorTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserComplexJoinDescriptorTest.java
@@ -41,7 +41,7 @@ public class QueryParserComplexJoinDescriptorTest {
         "`entity_table`.`group_id` = `join_tbl`.`id` " +
         "and `entity_table`.`tag` = `join_tbl`.`id` " +
         "and `join_tbl`.`meta_type` = 'joinObjects' ) " +
-        "where ifnull(`join_tbl`.`topic_id`, 0) = '123' " +
+        "where ifnull(`join_tbl`.`topic_id`, 0) = 123 " +
         "limit 10"
       );
   }

--- a/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserJoinTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserJoinTest.java
@@ -39,7 +39,7 @@ public class QueryParserJoinTest {
       .isEqualTo(
         "select distinct entity_table.* from entity_table " +
         "join `join_tbl` on `entity_table`.`id` = `join_tbl`.`entity_id` " +
-        "where `join_tbl`.`topic_id` = '123' limit 10"
+        "where `join_tbl`.`topic_id` = 123 limit 10"
       );
   }
 

--- a/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserSimpleJoinDescriptorTest.java
+++ b/httpql/src/test/java/com/hubspot/httpql/impl/QueryParserSimpleJoinDescriptorTest.java
@@ -38,7 +38,7 @@ public class QueryParserSimpleJoinDescriptorTest {
       .isEqualTo(
         "select distinct entity_table.* from entity_table " +
         "join `join_tbl` on `entity_table`.`id` = `join_tbl`.`entity_id` " +
-        "where `join_tbl`.`topic_id` = '123' limit 10"
+        "where `join_tbl`.`topic_id` = 123 limit 10"
       );
   }
 


### PR DESCRIPTION
Attempts resolution similar to the one in https://github.com/HubSpot/httpQL/pull/27 but attempts to not run into the same types of failures seen previously. Digging into JOOQ's source, it looks like [DSL::param](https://github.com/jOOQ/jOOQ/blob/2697190c02b60a0cbbb4682e2dae1261a779f62e/jOOQ/src/main/java/org/jooq/impl/DSL.java#L34261) returns a [Val](https://github.com/jOOQ/jOOQ/blob/2697190c02b60a0cbbb4682e2dae1261a779f62e/jOOQ/src/main/java/org/jooq/impl/Val.java#L102) object, which inherits the implementation of method [setConverted0](https://github.com/jOOQ/jOOQ/blob/2697190c02b60a0cbbb4682e2dae1261a779f62e/jOOQ/src/main/java/org/jooq/impl/AbstractParam.java#L166) (which is called via the inherited method [setConverted](https://github.com/jOOQ/jOOQ/blob/2697190c02b60a0cbbb4682e2dae1261a779f62e/jOOQ/src/main/java/org/jooq/impl/AbstractParamX.java#L78)). This inherited `setConverted0` method performs the conversion with `getDataType().convert(value)`, instead of `getType().cast(value)` used in https://github.com/HubSpot/httpQL/pull/27. This should hopefully get us the behavior we want without the whole mutation business.

https://github.com/HubSpot/httpQL/pull/27 eventually was reverted in https://github.com/HubSpot/httpQL/pull/28 due to failing builds because of failed casts. When I unreverted https://github.com/HubSpot/httpQL/pull/27 to test it out, it also caused [this more recent unit test to fail](https://github.com/HubSpot/httpQL/blame/f4ada8c1a5177810ee8686360479a4817adc6542/httpql/src/test/java/com/hubspot/httpql/SelectBuilderTest.java#L303), also due to a failed cast.

After making this change I verified locally that both the newer unit test and the test referenced in the slack thread which led to the revert (I can provide more details about this in slack if desired, but I thought I'd leave the private links out of the public GitHub) no longer experience failed casting, so I think we may be more successful with this approach.
