### PR TITLE
Update jooq to prevent class init deadlocks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
       <dependency>
         <groupId>org.jooq</groupId>
         <artifactId>jooq</artifactId>
-        <version>3.15.5</version>
+        <version>3.17.10</version>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
There is a jooq class init cycle in versions less than 3.17.10 that causes our application to occasionally deadlock upon receiving two requests on startup that initialize jooq classes in different orders. See: https://github.com/jOOQ/jOOQ/issues/14769. We have confirmed the same kind of behavior in our application's thread dumps.